### PR TITLE
Use Docker workflow with plugins

### DIFF
--- a/dev/django.Dockerfile
+++ b/dev/django.Dockerfile
@@ -16,8 +16,8 @@ ENV PYTHONUNBUFFERED 1
 COPY ./setup.py /opt/django-project/setup.py
 RUN pip install --editable /opt/django-project[dev]
 
+COPY ./atlascope_plugins/atlascope-vandy-importer/setup.py /opt/atlascope-plugins/atlascope-vandy-importer/setup.py
+RUN pip install --editable /opt/atlascope-plugins/atlascope-vandy-importer
+
 # Use a directory name which will never be an import name, as isort considers this as first-party.
 WORKDIR /opt/django-project
-
-COPY atlascope_plugins /opt/atlascope-plugins/
-RUN pip install --editable /opt/atlascope-plugins/*

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -10,6 +10,7 @@ services:
     env_file: ./dev/.env.docker-compose
     volumes:
       - .:/opt/django-project
+      - ./atlascope_plugins:/opt/atlascope-plugins
     ports:
       - 8000:8000
     depends_on:
@@ -33,6 +34,7 @@ services:
     env_file: ./dev/.env.docker-compose
     volumes:
       - .:/opt/django-project
+      - ./atlascope_plugins:/opt/atlascope-plugins
     depends_on:
       - postgres
       - rabbitmq


### PR DESCRIPTION
Closes #12

Changes to the plugins' source will be immediately reflected in the container running the debug server. This was accomplished by bind-mounting the plugin source directory into the Docker container via our Docker Compose configuration. An important caveat of this approach is that each plugin needs to be specifically installed in the Dockerfile.