### PR TITLE
Add InvestigationsList View

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -14,11 +14,13 @@
     "@sentry/vue": "^6.2.0",
     "@vue/composition-api": "^1.0.0-rc.2",
     "axios": "^0.21.1",
+    "direct-vuex": "^0.12.1",
     "geojs": "^1.4.3",
     "swagger-typescript-api": "^9.3.1",
     "vue": "^2.6.11",
     "vue-router": "^3.2.0",
-    "vuetify": "^2.4.0"
+    "vuetify": "^2.4.0",
+    "vuex": "^3.6.2"
   },
   "devDependencies": {
     "@types/jest": "^24.0.19",

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -1,5 +1,19 @@
 <template>
   <v-app>
+    <atlascope-toolbar />
     <router-view />
   </v-app>
 </template>
+
+<script lang="ts">
+import Vue from 'vue';
+import AtlascopeToolbar from './components/AtlascopeToolbar.vue';
+
+export default Vue.extend({
+  name: 'App',
+
+  components: {
+    AtlascopeToolbar,
+  },
+});
+</script>

--- a/web/src/components/AtlascopeToolbar.vue
+++ b/web/src/components/AtlascopeToolbar.vue
@@ -1,0 +1,73 @@
+<template>
+  <div>
+    <v-app-bar
+      color="teal darken-2"
+      dense
+      dark
+    >
+      <v-toolbar-title>
+        <router-link
+          :to="{name: 'investigationsList'}"
+          tag="button"
+        >
+          Atlascope
+        </router-link>
+      </v-toolbar-title>
+      <v-spacer />
+      <v-btn
+        v-if="userInfo"
+        text
+        @click="logInOrOut"
+      >
+        Logout
+      </v-btn>
+      <v-btn
+        v-if="!userInfo"
+        text
+        @click="logInOrOut"
+      >
+        Login
+      </v-btn>
+    </v-app-bar>
+  </div>
+</template>
+
+<script lang="ts">
+import {
+  defineComponent, inject, computed, onMounted,
+} from '@vue/composition-api';
+import OAuthClient from '@girder/oauth-client';
+import store from '../store';
+
+export default defineComponent({
+  setup() {
+    const oauthClient = inject<OAuthClient>('oauthClient');
+    const axios = inject('axios');
+    const userInfo = computed(() => store.state.userInfo);
+
+    if (oauthClient === undefined) {
+      throw new Error('Must provide "oauthClient" into component.');
+    }
+
+    onMounted(async () => {
+      await store.dispatch.fetchUserInfo(axios);
+    });
+
+    return { oauthClient, userInfo };
+  },
+
+  methods: {
+    async logInOrOut(): Promise<void> {
+      if (this.oauthClient.isLoggedIn) {
+        await this.oauthClient.logout();
+        store.dispatch.logout();
+        if (this.$router.currentRoute.name !== 'investigationsList') {
+          this.$router.push({ name: 'investigationsList' });
+        }
+      } else {
+        this.oauthClient.redirectToLogin();
+      }
+    },
+  },
+});
+</script>

--- a/web/src/components/LoginBanner.vue
+++ b/web/src/components/LoginBanner.vue
@@ -1,0 +1,8 @@
+<template>
+  <v-banner single-line>
+    <v-icon left>
+      mdi-alert
+    </v-icon>
+    You are not logged in. Please log in to continue to Atlascope.
+  </v-banner>
+</template>

--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -1,6 +1,8 @@
 import Vue from 'vue';
 import VueRouter, { RouteConfig } from 'vue-router';
 import Home from '../views/Home.vue';
+import InvestigationsList from '../views/InvestigationsList.vue';
+import InvestigationDetail from '../views/InvestigationDetail.vue';
 
 Vue.use(VueRouter);
 
@@ -8,6 +10,17 @@ const routes: Array<RouteConfig> = [
   {
     path: '/',
     component: Home,
+  },
+  {
+    path: '/investigations',
+    name: 'investigationsList',
+    component: InvestigationsList,
+  },
+  {
+    path: '/investigations/:investigation',
+    name: 'investigationDetail',
+    component: InvestigationDetail,
+    props: true,
   },
 ];
 

--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -1,6 +1,5 @@
 import Vue from 'vue';
 import VueRouter, { RouteConfig } from 'vue-router';
-import Home from '../views/Home.vue';
 import InvestigationsList from '../views/InvestigationsList.vue';
 import InvestigationDetail from '../views/InvestigationDetail.vue';
 
@@ -9,10 +8,6 @@ Vue.use(VueRouter);
 const routes: Array<RouteConfig> = [
   {
     path: '/',
-    component: Home,
-  },
-  {
-    path: '/investigations',
     name: 'investigationsList',
     component: InvestigationsList,
   },

--- a/web/src/store/index.ts
+++ b/web/src/store/index.ts
@@ -1,0 +1,66 @@
+import Vue from 'vue';
+import Vuex from 'vuex';
+import { createDirectStore } from 'direct-vuex';
+
+import { User, Investigation } from '../generatedTypes/AtlascopeTypes';
+
+Vue.use(Vuex);
+
+export interface State {
+    userInfo: User | null,
+    investigations: Investigation[],
+};
+
+const {
+    store,
+    rootActionContext,
+    moduleActionContext,
+    rootGetterContext,
+    moduleGetterContext,
+} = createDirectStore({
+    state: {
+        userInfo: null,
+        investigations: [],
+    } as State,
+    mutations: {
+        setInvestigations(state, investigations: Investigation[]) {
+            state.investigations = investigations;
+        },
+        setUserInfo(state, userInfo: User | null) {
+            state.userInfo = userInfo;
+        }
+    },
+    actions: {
+        async fetchInvestigations(context, axiosInstance) {
+            const { commit } = rootActionContext(context);
+            const investigations = (await axiosInstance.get('/investigations')).data;
+            commit.setInvestigations(investigations.results);
+        },
+        async fetchUserInfo(context, axiosInstance) {
+            const { commit } = rootActionContext(context);
+            const userInfo = (await axiosInstance.get('/users/me')).data;
+            commit.setUserInfo(userInfo);
+        },
+        logout(context) {
+            const { commit } = rootActionContext(context);
+            commit.setUserInfo(null);
+            commit.setInvestigations([]);
+        }
+    }
+});
+
+export default store;
+export {
+    rootActionContext,
+    moduleActionContext,
+    rootGetterContext,
+    moduleGetterContext,
+};
+
+// Enable types in injected $store
+export type ApplicationStore = typeof store;
+declare module 'vuex' {
+    interface Store<S> {
+        direct: ApplicationStore;
+    }
+};

--- a/web/src/store/index.ts
+++ b/web/src/store/index.ts
@@ -7,54 +7,54 @@ import { User, Investigation } from '../generatedTypes/AtlascopeTypes';
 Vue.use(Vuex);
 
 export interface State {
-    userInfo: User | null,
-    investigations: Investigation[],
-};
+    userInfo: User | null;
+    investigations: Investigation[];
+}
 
 const {
-    store,
-    rootActionContext,
-    moduleActionContext,
-    rootGetterContext,
-    moduleGetterContext,
+  store,
+  rootActionContext,
+  moduleActionContext,
+  rootGetterContext,
+  moduleGetterContext,
 } = createDirectStore({
-    state: {
-        userInfo: null,
-        investigations: [],
-    } as State,
-    mutations: {
-        setInvestigations(state, investigations: Investigation[]) {
-            state.investigations = investigations;
-        },
-        setUserInfo(state, userInfo: User | null) {
-            state.userInfo = userInfo;
-        }
+  state: {
+    userInfo: null,
+    investigations: [],
+  } as State,
+  mutations: {
+    setInvestigations(state, investigations: Investigation[]) {
+      state.investigations = investigations;
     },
-    actions: {
-        async fetchInvestigations(context, axiosInstance) {
-            const { commit } = rootActionContext(context);
-            const investigations = (await axiosInstance.get('/investigations')).data;
-            commit.setInvestigations(investigations.results);
-        },
-        async fetchUserInfo(context, axiosInstance) {
-            const { commit } = rootActionContext(context);
-            const userInfo = (await axiosInstance.get('/users/me')).data;
-            commit.setUserInfo(userInfo);
-        },
-        logout(context) {
-            const { commit } = rootActionContext(context);
-            commit.setUserInfo(null);
-            commit.setInvestigations([]);
-        }
-    }
+    setUserInfo(state, userInfo: User | null) {
+      state.userInfo = userInfo;
+    },
+  },
+  actions: {
+    async fetchInvestigations(context, axiosInstance) {
+      const { commit } = rootActionContext(context);
+      const investigations = (await axiosInstance.get('/investigations')).data;
+      commit.setInvestigations(investigations.results);
+    },
+    async fetchUserInfo(context, axiosInstance) {
+      const { commit } = rootActionContext(context);
+      const userInfo = (await axiosInstance.get('/users/me')).data;
+      commit.setUserInfo(userInfo);
+    },
+    logout(context) {
+      const { commit } = rootActionContext(context);
+      commit.setUserInfo(null);
+      commit.setInvestigations([]);
+    },
+  },
 });
 
 export default store;
 export {
-    rootActionContext,
-    moduleActionContext,
-    rootGetterContext,
-    moduleGetterContext,
+  rootActionContext,
+  moduleActionContext,
+  rootGetterContext,
+  moduleGetterContext,
 };
 
 // Enable types in injected $store
@@ -63,4 +63,4 @@ declare module 'vuex' {
     interface Store<S> {
         direct: ApplicationStore;
     }
-};
+}

--- a/web/src/views/InvestigationDetail.vue
+++ b/web/src/views/InvestigationDetail.vue
@@ -1,0 +1,43 @@
+<template>
+    <div ref="map" class="map" />
+</template>
+
+<style scoped>
+.map {
+    width: 100%;
+    height: 100%;
+    padding: 0;
+    margin: 0;
+    overflow: hidden;
+}
+</style>
+
+<script lang="ts">
+import {
+    ref, defineComponent, onMounted, PropType,
+} from '@vue/composition-api';
+import useGeoJS from '../utilities/useGeoJS';
+
+export default defineComponent({
+    name: 'InvestigationDetail',
+
+    props: {
+        investigation: {
+            type: String as PropType<string>,
+            required: true,
+        },
+    },
+
+    setup(props) {
+        const map = ref(null);
+        const { zoom, center } = useGeoJS(map);
+
+        onMounted(() => {
+            setTimeout(() => center(-0.1704, 51.5047), 2000);
+            setTimeout(() => zoom(14), 3000);
+            console.log(props.investigation);
+        });
+        return { map };
+    },
+});
+</script>

--- a/web/src/views/InvestigationDetail.vue
+++ b/web/src/views/InvestigationDetail.vue
@@ -1,5 +1,8 @@
 <template>
-    <div ref="map" class="map" />
+  <div
+    ref="map"
+    class="map"
+  />
 </template>
 
 <style scoped>
@@ -14,30 +17,29 @@
 
 <script lang="ts">
 import {
-    ref, defineComponent, onMounted, PropType,
+  ref, defineComponent, onMounted, PropType,
 } from '@vue/composition-api';
 import useGeoJS from '../utilities/useGeoJS';
 
 export default defineComponent({
-    name: 'InvestigationDetail',
+  name: 'InvestigationDetail',
 
-    props: {
-        investigation: {
-            type: String as PropType<string>,
-            required: true,
-        },
+  props: {
+    investigation: {
+      type: String as PropType<string>,
+      required: true,
     },
+  },
 
-    setup(props) {
-        const map = ref(null);
-        const { zoom, center } = useGeoJS(map);
+  setup(props) {
+    const map = ref(null);
+    const { zoom, center } = useGeoJS(map);
 
-        onMounted(() => {
-            setTimeout(() => center(-0.1704, 51.5047), 2000);
-            setTimeout(() => zoom(14), 3000);
-            console.log(props.investigation);
-        });
-        return { map };
-    },
+    onMounted(() => {
+      setTimeout(() => center(-0.1704, 51.5047), 2000);
+      setTimeout(() => zoom(14), 3000);
+    });
+    return { map };
+  },
 });
 </script>

--- a/web/src/views/InvestigationsList.vue
+++ b/web/src/views/InvestigationsList.vue
@@ -1,82 +1,95 @@
 <template>
-    <v-container class="pa-6" fluid>
-        <v-row class="pa-6">
-            <v-col v-for="investigation in investigations" :key="investigation.id" md="3">
-                <v-card elevation="9"  rounded-lg outline>
-                    <v-card-title>{{ investigation.name }}</v-card-title>
-                    <v-card-subtitle>{{ investigation.owner }}</v-card-subtitle>
-                    <v-card-text>{{ investigation.description }}</v-card-text>
-                    <v-card-actions>
-                        <router-link :to="`/investigations/${investigation.id}`">
-                            <v-btn color="blue" text>Investigate</v-btn>
-                        </router-link>
-                    </v-card-actions>
-                </v-card>
-            </v-col>
-        </v-row>
-    </v-container>
+  <v-container
+    class="pa-6"
+    fluid
+  >
+    <v-row
+      v-if="!userInfo"
+      class="pa-6"
+    >
+      <v-col md="9">
+        <v-card
+          elevation="9"
+          rounded-lg
+          outline
+        >
+          <v-card-title>Info:</v-card-title>
+          <v-card-text>Please log in to begin using Atlascope</v-card-text>
+        </v-card>
+      </v-col>
+    </v-row>
+    <v-row
+      v-else-if="investigations.length === 0"
+      class="pa-6"
+    >
+      <v-col md="9">
+        <v-card
+          elevation="9"
+          rounded-lg
+          outline
+        >
+          <v-card-title>Info:</v-card-title>
+          <v-card-text>Could not find existing investigations.</v-card-text>
+        </v-card>
+      </v-col>
+    </v-row>
+    <v-row
+      v-else
+      class="pa-6"
+    >
+      <v-col
+        v-for="investigation in investigations"
+        :key="investigation.id"
+        md="3"
+      >
+        <v-card
+          elevation="9"
+          rounded-lg
+          outline
+        >
+          <v-card-title>{{ investigation.name }}</v-card-title>
+          <v-card-subtitle>{{ investigation.owner }}</v-card-subtitle>
+          <v-card-text>{{ investigation.description }}</v-card-text>
+          <v-card-actions>
+            <router-link :to="`/investigations/${investigation.id}`">
+              <v-btn
+                color="blue"
+                text
+              >
+                Investigate
+              </v-btn>
+            </router-link>
+          </v-card-actions>
+        </v-card>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 
 <script lang="ts">
-import Vue, { PropType } from 'vue';
-import { Investigation } from '../generatedTypes/AtlascopeTypes';
+import { AxiosInstance } from 'axios';
+import Vue from 'vue';
+import { computed, inject, onMounted } from '@vue/composition-api';
+
+import store from '../store';
 
 export default Vue.extend({
-    props: {
+  setup() {
+    const axiosInstance = inject<AxiosInstance>('axios');
+    const investigations = computed(() => store.state.investigations);
+    const userInfo = computed(() => store.state.userInfo);
 
-    },
+    onMounted(async () => {
+      if (axiosInstance) {
+        await store.dispatch.fetchInvestigations(axiosInstance);
+      }
+    });
 
-    data() {
-        return {};
-    },
-
-    computed: {
-        investigations(): Array<Investigation> {
-            return [
-                {
-                    id: '1',
-                    name: 'Investigation 1',
-                    description: 'Lorem ipsum ...',
-                    owner: 'Alice',
-                },
-                {
-                    id: '2',
-                    name: 'Investigation 2',
-                    description: 'Lorem ipsum ...',
-                    owner: 'Bob',
-                },
-                {
-                    id: '3',
-                    name: 'Investigation 3',
-                    description: 'Lorem ipsum ...',
-                    owner: 'Carol',
-                },
-                {
-                    id: '4',
-                    name: 'Investigation 4',
-                    description: 'Lorem ipsum ...',
-                    owner: 'Dan',
-                },
-                {
-                    id: '5',
-                    name: 'Investigation 5',
-                    description: 'Lorem ipsum ...',
-                    owner: 'Eileen',
-                },
-                {
-                    id: '6',
-                    name: 'Investigation 6',
-                    description: 'Lorem ipsum ...',
-                    owner: 'Frank',
-                },
-            ];
-        },
-    },
-
-    methods: {
-        printSomething() {
-            console.log('Clicked a card action');
-        },
-    },
+    return {
+      axiosInstance,
+      investigations,
+      userInfo,
+    };
+  },
 });
 </script>

--- a/web/src/views/InvestigationsList.vue
+++ b/web/src/views/InvestigationsList.vue
@@ -1,0 +1,82 @@
+<template>
+    <v-container class="pa-6" fluid>
+        <v-row class="pa-6">
+            <v-col v-for="investigation in investigations" :key="investigation.id" md="3">
+                <v-card elevation="9"  rounded-lg outline>
+                    <v-card-title>{{ investigation.name }}</v-card-title>
+                    <v-card-subtitle>{{ investigation.owner }}</v-card-subtitle>
+                    <v-card-text>{{ investigation.description }}</v-card-text>
+                    <v-card-actions>
+                        <router-link :to="`/investigations/${investigation.id}`">
+                            <v-btn color="blue" text>Investigate</v-btn>
+                        </router-link>
+                    </v-card-actions>
+                </v-card>
+            </v-col>
+        </v-row>
+    </v-container>
+</template>
+
+<script lang="ts">
+import Vue, { PropType } from 'vue';
+import { Investigation } from '../generatedTypes/AtlascopeTypes';
+
+export default Vue.extend({
+    props: {
+
+    },
+
+    data() {
+        return {};
+    },
+
+    computed: {
+        investigations(): Array<Investigation> {
+            return [
+                {
+                    id: '1',
+                    name: 'Investigation 1',
+                    description: 'Lorem ipsum ...',
+                    owner: 'Alice',
+                },
+                {
+                    id: '2',
+                    name: 'Investigation 2',
+                    description: 'Lorem ipsum ...',
+                    owner: 'Bob',
+                },
+                {
+                    id: '3',
+                    name: 'Investigation 3',
+                    description: 'Lorem ipsum ...',
+                    owner: 'Carol',
+                },
+                {
+                    id: '4',
+                    name: 'Investigation 4',
+                    description: 'Lorem ipsum ...',
+                    owner: 'Dan',
+                },
+                {
+                    id: '5',
+                    name: 'Investigation 5',
+                    description: 'Lorem ipsum ...',
+                    owner: 'Eileen',
+                },
+                {
+                    id: '6',
+                    name: 'Investigation 6',
+                    description: 'Lorem ipsum ...',
+                    owner: 'Frank',
+                },
+            ];
+        },
+    },
+
+    methods: {
+        printSomething() {
+            console.log('Clicked a card action');
+        },
+    },
+});
+</script>

--- a/web/src/views/InvestigationsList.vue
+++ b/web/src/views/InvestigationsList.vue
@@ -3,36 +3,16 @@
     class="pa-6"
     fluid
   >
-    <v-row
-      v-if="!userInfo"
-      class="pa-6"
-    >
-      <v-col md="9">
-        <v-card
-          elevation="9"
-          rounded-lg
-          outline
-        >
-          <v-card-title>Info:</v-card-title>
-          <v-card-text>Please log in to begin using Atlascope</v-card-text>
-        </v-card>
-      </v-col>
-    </v-row>
-    <v-row
+    <login-banner v-if="!userInfo" />
+    <v-banner
       v-else-if="investigations.length === 0"
-      class="pa-6"
+      single-line
     >
-      <v-col md="9">
-        <v-card
-          elevation="9"
-          rounded-lg
-          outline
-        >
-          <v-card-title>Info:</v-card-title>
-          <v-card-text>Could not find existing investigations.</v-card-text>
-        </v-card>
-      </v-col>
-    </v-row>
+      <v-icon left>
+        mdi-information
+      </v-icon>
+      Could not find any existing investigations.
+    </v-banner>
     <v-row
       v-else
       class="pa-6"
@@ -70,10 +50,15 @@
 import { AxiosInstance } from 'axios';
 import Vue from 'vue';
 import { computed, inject, onMounted } from '@vue/composition-api';
+import LoginBanner from '../components/LoginBanner.vue';
 
 import store from '../store';
 
 export default Vue.extend({
+  components: {
+    LoginBanner,
+  },
+
   setup() {
     const axiosInstance = inject<AxiosInstance>('axios');
     const investigations = computed(() => store.state.investigations);

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -3229,6 +3229,11 @@ dir-glob@^2.0.0, dir-glob@^2.2.2:
   dependencies:
     path-type "^3.0.0"
 
+direct-vuex@^0.12.1:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/direct-vuex/-/direct-vuex-0.12.1.tgz#19afc96b58faa3414837ae06154897a381a9a8af"
+  integrity sha512-U1eVqJuUasjZvpTUBvogfTEWkvPPntqimK5pzZKehuPeGMvMbb/iimP/ahsG+G4vsZDOY4IsRtq8x2xsAl+fmQ==
+
 dns-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/dns-equal/-/dns-equal-1.0.0.tgz#b39e7f1da6eb0a75ba9c17324b34753c47e0654d"
@@ -10081,6 +10086,11 @@ vuetify@^2.4.0:
   version "2.4.5"
   resolved "https://registry.yarnpkg.com/vuetify/-/vuetify-2.4.5.tgz#86de190720d25511df9be37ff3c16a568972fc2d"
   integrity sha512-P4bN9xwyU91Iq1iW/XBCzgVMQ9fHG0HgJeiPDRoHzC0fX6ZPYBZIN6xPCuoG7zLyGSSoc6JnQqnO7H5mPEsVuA==
+
+vuex@^3.6.2:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/vuex/-/vuex-3.6.2.tgz#236bc086a870c3ae79946f107f16de59d5895e71"
+  integrity sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw==
 
 w3c-hr-time@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
This PR makes the following changes:

- Add ability to log in/log out through OAuth to Atlascope backend. This allows for making authenticated requests to the back end
- Add an app-wide toolbar with some basic functionality (log in/out, navigate back to home view)
- Create a page for displaying existing investigations. For now, this is the default view for Atlascope.

Workflow to test:

1. Spin up the Atlascope Django back end. Be sure to provision data (instructions can be found in the top-level `README.md`).
2. Spin up the Atlascope front end. Instructions can be found in `web/README.md`.
3. Navigate to http://localhost:8080
4. If you are not logged in, you should see a banner notifying you that you should log in
5. If you are logged in, you should see a card for each investigation in the database
6. If there are no investigations and you are logged in, you should see a banner calling out that no investigations could be found
7. Click `Investigate` on any of the cards. You should be redirected to the investigation detail page, which currently does nothing except display an OSM image.
8. Click `Atlascope` in the toolbar. You should be brought back to the initial list of investigations.
9. Click `Logout`. The list of investigations should vanish and you should see the banner asking you to login again.