### PR TITLE
Test `populate` script with serializer

### DIFF
--- a/atlascope/tests/test_dataloader.py
+++ b/atlascope/tests/test_dataloader.py
@@ -1,10 +1,11 @@
 import json
+
+from django.contrib.auth.models import User
 import pytest
 from rest_framework import serializers
-from django.contrib.auth.models import User
 
 from atlascope.core import models as atlascope_models
-from atlascope.core.management.commands.populate import MODEL_JSON_MAPPING, DATALOADER_DIR
+from atlascope.core.management.commands.populate import DATALOADER_DIR, MODEL_JSON_MAPPING
 from atlascope.core.rest.additional_serializers import UserSerializer
 
 

--- a/atlascope/tests/test_dataloader.py
+++ b/atlascope/tests/test_dataloader.py
@@ -21,4 +21,4 @@ def test_serializers_valid():
     for model, filename in MODEL_JSON_MAPPING:
         objects = json.load(open(DATALOADER_DIR + filename))
         for data_obj in objects:
-            model_serializers[model](data=data_obj).is_valid()
+            model_serializers[model](data=data_obj).is_valid(raise_exception=True)

--- a/atlascope/tests/test_dataloader.py
+++ b/atlascope/tests/test_dataloader.py
@@ -1,4 +1,5 @@
 import json
+from typing import Iterator, Tuple
 
 from django.contrib.auth.models import User
 import pytest
@@ -8,17 +9,21 @@ from atlascope.core import models as atlascope_models
 from atlascope.core.management.commands.populate import DATALOADER_DIR, MODEL_JSON_MAPPING
 from atlascope.core.rest.additional_serializers import UserSerializer
 
-
-@pytest.mark.django_db
-def test_serializers_valid():
+def serializer_dataloader_objects() -> Iterator[Tuple[serializers.ModelSerializer,dict]]:
     model_serializers = {
         clas.Meta.model: clas
         for clas in atlascope_models.__all__
         if issubclass(clas, serializers.ModelSerializer)
     }
     model_serializers[User] = UserSerializer
-
     for model, filename in MODEL_JSON_MAPPING:
-        objects = json.load(open(DATALOADER_DIR + filename))
-        for data_obj in objects:
-            model_serializers[model](data=data_obj).is_valid(raise_exception=True)
+        serializer = model_serializers[model]
+        with open(DATALOADER_DIR + filename, 'r') as dataloader_file:
+            dataloader_objects = json.load(dataloader_file)
+            for dataloader_object in dataloader_objects:
+                yield serializer, dataloader_object
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("serializer,data_obj", serializer_dataloader_objects())
+def test_serializers_valid(serializer, data_obj):
+    serializer(data=data_obj).is_valid(raise_exception=True)

--- a/atlascope/tests/test_dataloader.py
+++ b/atlascope/tests/test_dataloader.py
@@ -9,7 +9,8 @@ from atlascope.core import models as atlascope_models
 from atlascope.core.management.commands.populate import DATALOADER_DIR, MODEL_JSON_MAPPING
 from atlascope.core.rest.additional_serializers import UserSerializer
 
-def serializer_dataloader_objects() -> Iterator[Tuple[serializers.ModelSerializer,dict]]:
+
+def serializer_dataloader_objects() -> Iterator[Tuple[serializers.ModelSerializer, dict]]:
     model_serializers = {
         clas.Meta.model: clas
         for clas in atlascope_models.__all__
@@ -22,6 +23,7 @@ def serializer_dataloader_objects() -> Iterator[Tuple[serializers.ModelSerialize
             dataloader_objects = json.load(dataloader_file)
             for dataloader_object in dataloader_objects:
                 yield serializer, dataloader_object
+
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("serializer,data_obj", serializer_dataloader_objects())

--- a/atlascope/tests/test_dataloader.py
+++ b/atlascope/tests/test_dataloader.py
@@ -1,0 +1,23 @@
+import json
+import pytest
+from rest_framework import serializers
+from django.contrib.auth.models import User
+
+from atlascope.core import models as atlascope_models
+from atlascope.core.management.commands.populate import MODEL_JSON_MAPPING, DATALOADER_DIR
+from atlascope.core.rest.additional_serializers import UserSerializer
+
+
+@pytest.mark.django_db
+def test_serializers_valid():
+    model_serializers = {
+        clas.Meta.model: clas
+        for clas in atlascope_models.__all__
+        if issubclass(clas, serializers.ModelSerializer)
+    }
+    model_serializers[User] = UserSerializer
+
+    for model, filename in MODEL_JSON_MAPPING:
+        objects = json.load(open(DATALOADER_DIR + filename))
+        for data_obj in objects:
+            model_serializers[model](data=data_obj).is_valid()

--- a/tox.ini
+++ b/tox.ini
@@ -42,6 +42,7 @@ passenv =
 extras =
     dev
 deps =
+    ./atlascope_plugins/atlascope-vandy-importer
     factory-boy
     pytest
     pytest-django
@@ -72,6 +73,7 @@ passenv =
 extras =
     dev
 deps =
+    ./atlascope_plugins/atlascope-vandy-importer
     # We explicitly reference `gdal` and `pyproj` here
     # so that their versions can be constrained
     # with tox's `--force-dep` option.


### PR DESCRIPTION
Test related changes copied over from #32

The fixtures should be validated with our serializers during testing. Otherwise we risk having corrupt seed data when new business logic is expressed in the serializers.