### PR TITLE
Change auto-generated pw in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is the simplest configuration for developers to start with.
 
 ### Initial Setup
 1. Run `docker-compose run --rm django ./manage.py migrate`
-2. Populate the database with sample data using `docker-compose run --rm django ./manage.py populate --password=[USERS_PASSWORD]`. If you do not specify a password, the default password for all created users will be "123".
+2. Populate the database with sample data using `docker-compose run --rm django ./manage.py populate --password=[USERS_PASSWORD]`. If you do not specify a password, the default password for all created users will be `letmein`.
 3. OR run `docker-compose run --rm django ./manage.py createsuperuser`
    and follow the prompts to create your own user
 


### PR DESCRIPTION
Closes #40 
This keeps the "Initial Setup" section of the `README` in sync with changes from 6fa5c2d. In particular, the password used by the `populate` command when setting up a fresh instance of the Atlascope back end was changed from `123` to `letmein`.