### PR TITLE
Update default client URI

### DIFF
--- a/atlascope/core/management/commands/populate.py
+++ b/atlascope/core/management/commands/populate.py
@@ -21,7 +21,7 @@ MODEL_JSON_MAPPING = [
 
 DEFAULT_PASSWORD = 'letmein'
 
-DEFAULT_CLIENT_URI = 'http://localhost:8081/'
+DEFAULT_CLIENT_URI = 'http://localhost:8080/'
 
 
 def expand_references(obj, model):


### PR DESCRIPTION
Closes #43 

The default port for the front end is `8080`. This PR updates the default client URI in the `populate.py` script to reflect this.

`localhost:8080` -> `localhost:8081`