### PR TITLE
Create initial detail view for Investigations

### DIFF
--- a/web/src/components/AtlascopeToolbar.vue
+++ b/web/src/components/AtlascopeToolbar.vue
@@ -14,6 +14,8 @@
         </router-link>
       </v-toolbar-title>
       <v-spacer />
+      <v-toolbar-title> {{ investigationName }}</v-toolbar-title>
+      <v-spacer />
       <v-btn
         v-if="userInfo"
         text
@@ -42,18 +44,18 @@ import store from '../store';
 export default defineComponent({
   setup() {
     const oauthClient = inject<OAuthClient>('oauthClient');
-    const axios = inject('axios');
     const userInfo = computed(() => store.state.userInfo);
+    const investigationName = computed(() => store.state.currentInvestigation?.name);
 
     if (oauthClient === undefined) {
       throw new Error('Must provide "oauthClient" into component.');
     }
 
     onMounted(async () => {
-      await store.dispatch.fetchUserInfo(axios);
+      await store.dispatch.fetchUserInfo();
     });
 
-    return { oauthClient, userInfo };
+    return { oauthClient, userInfo, investigationName };
   },
 
   methods: {

--- a/web/src/components/InvestigationSidebar.vue
+++ b/web/src/components/InvestigationSidebar.vue
@@ -44,7 +44,7 @@ import PinList from './PinList.vue';
 
 export default defineComponent({
   components: {
-    PinList
+    PinList,
   },
 
   setup() {

--- a/web/src/components/InvestigationSidebar.vue
+++ b/web/src/components/InvestigationSidebar.vue
@@ -11,7 +11,9 @@
         <v-expansion-panel-header>
           Pins
         </v-expansion-panel-header>
-        <v-expansion-panel-content />
+        <v-expansion-panel-content>
+          <pin-list />
+        </v-expansion-panel-content>
       </v-expansion-panel>
       <v-expansion-panel>
         <v-expansion-panel-header>
@@ -38,8 +40,13 @@ import {
   defineComponent, computed,
 } from '@vue/composition-api';
 import store from '../store';
+import PinList from './PinList.vue';
 
 export default defineComponent({
+  components: {
+    PinList
+  },
+
   setup() {
     const metadataFields = [
       'id',

--- a/web/src/components/InvestigationSidebar.vue
+++ b/web/src/components/InvestigationSidebar.vue
@@ -1,12 +1,18 @@
 <template>
   <v-sheet
-    max-width="500px"
-    min-width="500px"
+    max-width="33vw"
+    min-width="33vw"
   >
     <v-expansion-panels
       accordian
       flat
     >
+      <v-expansion-panel>
+        <v-expansion-panel-header>
+          Pins
+        </v-expansion-panel-header>
+        <v-expansion-panel-content />
+      </v-expansion-panel>
       <v-expansion-panel>
         <v-expansion-panel-header>
           Metadata
@@ -45,9 +51,9 @@ export default defineComponent({
       'description',
       'notes',
     ];
-    const investigationMetadata = computed(() => {
-      JSON.stringify(store.state.currentInvestigation, metadataFields, 4);
-    });
+    const investigationMetadata = computed(
+      () => JSON.stringify(store.state.currentInvestigation, metadataFields, 4),
+    );
     return { investigationMetadata };
   },
 });

--- a/web/src/components/InvestigationSidebar.vue
+++ b/web/src/components/InvestigationSidebar.vue
@@ -1,0 +1,54 @@
+<template>
+  <v-sheet
+    max-width="500px"
+    min-width="500px"
+  >
+    <v-expansion-panels
+      accordian
+      flat
+    >
+      <v-expansion-panel>
+        <v-expansion-panel-header>
+          Metadata
+        </v-expansion-panel-header>
+        <v-expansion-panel-content>
+          <span class="metadata">
+            {{ investigationMetadata }}
+          </span>
+        </v-expansion-panel-content>
+      </v-expansion-panel>
+    </v-expansion-panels>
+  </v-sheet>
+</template>
+
+<style scoped>
+.metadata {
+    white-space: pre;
+}
+</style>
+
+<script lang="ts">
+import {
+  defineComponent, computed,
+} from '@vue/composition-api';
+import store from '../store';
+
+export default defineComponent({
+  setup() {
+    const metadataFields = [
+      'id',
+      'owner',
+      'investigators',
+      'ovservers',
+      'created',
+      'updated',
+      'description',
+      'notes',
+    ];
+    const investigationMetadata = computed(() => {
+      JSON.stringify(store.state.currentInvestigation, metadataFields, 4);
+    });
+    return { investigationMetadata };
+  },
+});
+</script>

--- a/web/src/components/PinList.vue
+++ b/web/src/components/PinList.vue
@@ -1,26 +1,35 @@
 <template>
-    <v-list dense  flat class="pa-0 ma-0">
-        <v-list-item-group v-model="selectedItem">
-            <v-list-item v-for="pin in pins" :key="pin.id">
-                <v-list-item-icon>
-                <v-icon :color="pin.color">mdi-circle</v-icon>
-                </v-list-item-icon>
-                <v-list-item-content>
-                    {{ pin.id }}
-                </v-list-item-content>
-            </v-list-item>
-        </v-list-item-group>
-    </v-list>
+  <v-list
+    dense
+    flat
+    class="pa-0 ma-0"
+  >
+    <v-list-item-group v-model="selectedItem">
+      <v-list-item
+        v-for="pin in pins"
+        :key="pin.id"
+      >
+        <v-list-item-icon>
+          <v-icon :color="pin.color">
+            mdi-circle
+          </v-icon>
+        </v-list-item-icon>
+        <v-list-item-content>
+          {{ pin.id }}
+        </v-list-item-content>
+      </v-list-item>
+    </v-list-item-group>
+  </v-list>
 </template>
 
 <script lang="ts">
-import { computed, defineComponent } from '@vue/composition-api'
+import { computed, defineComponent } from '@vue/composition-api';
 import store from '../store';
 
 export default defineComponent({
-    setup() {
-        const pins = computed(() => store.getters.pins);
-        return { pins };
-    },
-})
+  setup() {
+    const pins = computed(() => store.getters.pins);
+    return { pins };
+  },
+});
 </script>

--- a/web/src/components/PinList.vue
+++ b/web/src/components/PinList.vue
@@ -1,0 +1,26 @@
+<template>
+    <v-list dense  flat class="pa-0 ma-0">
+        <v-list-item-group v-model="selectedItem">
+            <v-list-item v-for="pin in pins" :key="pin.id">
+                <v-list-item-icon>
+                <v-icon :color="pin.color">mdi-circle</v-icon>
+                </v-list-item-icon>
+                <v-list-item-content>
+                    {{ pin.id }}
+                </v-list-item-content>
+            </v-list-item>
+        </v-list-item-group>
+    </v-list>
+</template>
+
+<script lang="ts">
+import { computed, defineComponent } from '@vue/composition-api'
+import store from '../store';
+
+export default defineComponent({
+    setup() {
+        const pins = computed(() => store.getters.pins);
+        return { pins };
+    },
+})
+</script>

--- a/web/src/generatedTypes/AtlascopeTypes.ts
+++ b/web/src/generatedTypes/AtlascopeTypes.ts
@@ -30,6 +30,49 @@ export interface Dataset {
 
   /** Importer */
   importer?: string | null;
+
+  /**
+   * Content
+   * @format uri
+   */
+  content?: string | null;
+
+  /** Metadata */
+  metadata?: object | null;
+
+  /** Dataset type */
+  dataset_type?: "tile_source" | "tile_overlay" | "analytics";
+  derived_datasets?: string[];
+}
+
+export interface TileMetadata {
+  /**
+   * Levels
+   * Number of zoom levels in the image.
+   * @min 1
+   */
+  levels?: number;
+
+  /**
+   * Size x
+   * Image size in the X direction.
+   * @min 1
+   */
+  size_x?: number;
+
+  /**
+   * Size y
+   * Image size in the Y direction.
+   * @min 1
+   */
+  size_y?: number;
+
+  /**
+   * Tile size
+   * Size of the square tiles the image is composed of.
+   * @min 1
+   */
+  tile_size?: number;
 }
 
 export interface Investigation {
@@ -195,6 +238,35 @@ export namespace Datasets {
     export type RequestHeaders = {};
     export type ResponseBody = void;
   }
+  /**
+   * No description
+   * @tags datasets
+   * @name DatasetsTilesMetadataRead
+   * @request GET:/datasets/{id}/tiles/metadata
+   * @response `200` `TileMetadata`
+   */
+  export namespace DatasetsTilesMetadataRead {
+    export type RequestParams = { id: string };
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type RequestHeaders = {};
+    export type ResponseBody = TileMetadata;
+  }
+  /**
+   * No description
+   * @tags datasets
+   * @name DatasetsTilesRead
+   * @request GET:/datasets/{id}/tiles/{z}/{x}/{y}.png
+   * @response `200` `void` Image file
+   * @response `404` `void` Image tile not found
+   */
+  export namespace DatasetsTilesRead {
+    export type RequestParams = { id: string; x: number; y: number; z: number };
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type RequestHeaders = {};
+    export type ResponseBody = void;
+  }
 }
 
 export namespace Investigations {
@@ -247,6 +319,51 @@ export namespace Investigations {
   }
 }
 
+export namespace S3Upload {
+  /**
+   * No description
+   * @tags s3-upload
+   * @name S3UploadFinalizeCreate
+   * @request POST:/s3-upload/finalize/
+   * @response `201` `void`
+   */
+  export namespace S3UploadFinalizeCreate {
+    export type RequestParams = {};
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type RequestHeaders = {};
+    export type ResponseBody = void;
+  }
+  /**
+   * No description
+   * @tags s3-upload
+   * @name S3UploadUploadCompleteCreate
+   * @request POST:/s3-upload/upload-complete/
+   * @response `201` `void`
+   */
+  export namespace S3UploadUploadCompleteCreate {
+    export type RequestParams = {};
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type RequestHeaders = {};
+    export type ResponseBody = void;
+  }
+  /**
+   * No description
+   * @tags s3-upload
+   * @name S3UploadUploadInitializeCreate
+   * @request POST:/s3-upload/upload-initialize/
+   * @response `201` `void`
+   */
+  export namespace S3UploadUploadInitializeCreate {
+    export type RequestParams = {};
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type RequestHeaders = {};
+    export type ResponseBody = void;
+  }
+}
+
 export namespace Users {
   /**
    * No description
@@ -265,11 +382,11 @@ export namespace Users {
   /**
    * @description Return the currently logged in user's information.
    * @tags users
-   * @name UsersMe
+   * @name UsersMeRead
    * @request GET:/users/me
    * @response `200` `(User)[]`
    */
-  export namespace UsersMe {
+  export namespace UsersMeRead {
     export type RequestParams = {};
     export type RequestQuery = {};
     export type RequestBody = never;

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -5,6 +5,7 @@ import Vue from 'vue';
 import VueCompositionAPI from '@vue/composition-api';
 import App from './App.vue';
 import router from './router';
+import store from './store';
 import vuetify from './plugins/vuetify';
 
 Vue.use(VueCompositionAPI);
@@ -26,6 +27,7 @@ Sentry.init({
 oauthClient.maybeRestoreLogin().then(async () => {
   Object.assign(axiosInstance.defaults.headers.common, oauthClient.authHeaders);
 
+  store.dispatch.storeAxiosInstance(axiosInstance);
   new Vue({
     provide: {
       axios: axiosInstance,

--- a/web/src/store/index.ts
+++ b/web/src/store/index.ts
@@ -41,6 +41,28 @@ const {
       state.axiosInstance = axiosInstance;
     },
   },
+  getters: {
+    pins(state: State): any[] {
+      if (state.currentInvestigation !== null) {
+        // Use placeholders until GET /pins is implemented
+        return [
+          {
+            id: 'pin_1',
+            dataset: null,
+            color: 'red',
+            note: 'I am only a test pin.',
+          },
+          {
+            id: 'pin_2',
+            dataset: null,
+            color: 'green',
+            note: 'I am also just a test pin.',
+          },
+        ];
+      }
+      return [];
+    }
+  },
   actions: {
     async fetchInvestigations(context) {
       const { commit } = rootActionContext(context);

--- a/web/src/store/index.ts
+++ b/web/src/store/index.ts
@@ -61,7 +61,7 @@ const {
         ];
       }
       return [];
-    }
+    },
   },
   actions: {
     async fetchInvestigations(context) {

--- a/web/src/store/index.ts
+++ b/web/src/store/index.ts
@@ -76,6 +76,10 @@ const {
       const { commit } = rootActionContext(context);
       commit.setAxiosInstance(axiosInstance);
     },
+    unsetCurrentInvestigation(context) {
+      const { commit } = rootActionContext(context);
+      commit.setCurrentInvestigation(null);
+    },
   },
 });
 

--- a/web/src/views/InvestigationDetail.vue
+++ b/web/src/views/InvestigationDetail.vue
@@ -1,8 +1,42 @@
 <template>
-  <div
-    ref="map"
-    class="map"
-  />
+  <v-container
+    class="grey lighten-3 pa-0 ma-0"
+    fluid
+    fill-height
+  >
+    <v-row class="ma-0 pa-0">
+      <v-col class="ma-0 pa-0">
+        <v-sheet height="90vh">
+          <div
+            ref="map"
+            class="map"
+          />
+        </v-sheet>
+      </v-col>
+      <v-col
+        cols="auto"
+        class="ma-0 pa-0"
+      >
+        <v-sheet
+          height="90vh"
+          color="teal"
+        >
+          <v-btn
+            icon
+            @click.stop="toggleSidebar"
+          >
+            <v-icon v-if="sidebarCollapsed">
+              mdi-chevron-left
+            </v-icon>
+            <v-icon v-else>
+              mdi-chevron-right
+            </v-icon>
+          </v-btn>
+          <investigation-sidebar v-if="!sidebarCollapsed" />
+        </v-sheet>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 
 <style scoped>
@@ -11,7 +45,6 @@
     height: 100%;
     padding: 0;
     margin: 0;
-    overflow: hidden;
 }
 </style>
 
@@ -20,9 +53,15 @@ import {
   ref, defineComponent, onMounted, PropType,
 } from '@vue/composition-api';
 import useGeoJS from '../utilities/useGeoJS';
+import store from '../store';
+import InvestigationSidebar from '../components/InvestigationSidebar.vue';
 
 export default defineComponent({
   name: 'InvestigationDetail',
+
+  components: {
+    InvestigationSidebar,
+  },
 
   props: {
     investigation: {
@@ -33,13 +72,23 @@ export default defineComponent({
 
   setup(props) {
     const map = ref(null);
+    const sidebarCollapsed = ref(true);
     const { zoom, center } = useGeoJS(map);
+    const datasets = ['Dataset 1', 'Dataset 2', 'Dataset 3'];
+    const mainViews = ['context', 'connections'];
 
-    onMounted(() => {
+    function toggleSidebar() {
+      sidebarCollapsed.value = !sidebarCollapsed.value;
+    }
+
+    onMounted(async () => {
       setTimeout(() => center(-0.1704, 51.5047), 2000);
       setTimeout(() => zoom(14), 3000);
+      await store.dispatch.fetchCurrentInvestigation(props.investigation);
     });
-    return { map };
+    return {
+      map, datasets, mainViews, sidebarCollapsed, toggleSidebar,
+    };
   },
 });
 </script>

--- a/web/src/views/InvestigationsList.vue
+++ b/web/src/views/InvestigationsList.vue
@@ -64,6 +64,7 @@ export default Vue.extend({
 
     onMounted(async () => {
       await store.dispatch.fetchInvestigations();
+      store.dispatch.unsetCurrentInvestigation();
     });
 
     return {

--- a/web/src/views/InvestigationsList.vue
+++ b/web/src/views/InvestigationsList.vue
@@ -47,9 +47,8 @@
 </template>
 
 <script lang="ts">
-import { AxiosInstance } from 'axios';
 import Vue from 'vue';
-import { computed, inject, onMounted } from '@vue/composition-api';
+import { computed, onMounted } from '@vue/composition-api';
 import LoginBanner from '../components/LoginBanner.vue';
 
 import store from '../store';
@@ -60,18 +59,14 @@ export default Vue.extend({
   },
 
   setup() {
-    const axiosInstance = inject<AxiosInstance>('axios');
     const investigations = computed(() => store.state.investigations);
     const userInfo = computed(() => store.state.userInfo);
 
     onMounted(async () => {
-      if (axiosInstance) {
-        await store.dispatch.fetchInvestigations(axiosInstance);
-      }
+      await store.dispatch.fetchInvestigations();
     });
 
     return {
-      axiosInstance,
       investigations,
       userInfo,
     };


### PR DESCRIPTION
Closes #47

This PR adds the following changes:

- Update client-side typings from recent back end development
- Update store to include the axios instance from `main.ts`. Eventually this should likely be moved elsewhere
- Add `getters` and `getters.pins` to the store
- Add investigation title to toolbar when on the detail view
- Create initial `InvestigationDetail.vue`, including a map and sidebar
- Add some basic functionality to sidebar: display pins and metadata

Workflow walk through:

1. Follow the instructions in the various `README`s to set up an Atlascope front end and back end locally. Configfure OAuth so you can use the login functionality.
2. Run the `populate` command to get some data in to the system.
3. Navigate to `localhost:8080` (or wherever your front end is running) and login. Select any investigation from the initial list by clicking `Investigate`
4. You should be brought to the detail view for the investigation. The name of the investigation should now be displayed in the center of the App bar at the top of the page.
5. You should see a map view and a collapsed sidebar on the right hand side of the screen. Click the chevron to expand the sidebar.
6. The sidebar should contain two expansion panels: Pins and Metadata.
7. The pins panel shows two dummy pins (just their color and ID for now)
8. The metadata panel shows some metadata about the investigation.
9. Navigate back to the home page. The investigation name should be removed from the App bar.
10. Click a different investigation and repeat 4-8. The pins shown will be the same, but verify that the metadata is correct for the investigation you've chosen.