### PR TITLE
Add pytest for populate script

### DIFF
--- a/atlascope/core/importers/vandy.py
+++ b/atlascope/core/importers/vandy.py
@@ -18,7 +18,11 @@ class VandyImporter(AtlascopeImporter):
 
         params = {"key": api_key}
         token_url = "https://styx.neurology.emory.edu/girder/api/v1/api_key/token"
-        token = requests.post(token_url, params=params).json()["authToken"]["token"]
+        token_res = requests.post(token_url, params=params).json()
+        if 'authToken' not in token_res:
+            return
+
+        token = token_res["authToken"]["token"]
         headers = {"girder-token": token}
 
         source_url = f"https://styx.neurology.emory.edu/girder/api/v1/file/{file_id}/download"

--- a/atlascope/core/management/commands/populate.py
+++ b/atlascope/core/management/commands/populate.py
@@ -1,5 +1,5 @@
-import os
 import json
+import os
 from pathlib import Path
 
 from django.contrib.auth.models import User

--- a/atlascope/tests/test_populate.py
+++ b/atlascope/tests/test_populate.py
@@ -1,5 +1,5 @@
-import os
 import pytest
+
 from atlascope.core.management.commands.populate import command as populate_command
 
 

--- a/atlascope/tests/test_populate.py
+++ b/atlascope/tests/test_populate.py
@@ -1,0 +1,8 @@
+import os
+import pytest
+from atlascope.core.management.commands.populate import command as populate_command
+
+
+@pytest.mark.django_db
+def test_populate_script():
+    populate_command()


### PR DESCRIPTION
Replaces #44, now using the native importer definitions. Instead of testing each serializer on the objects written in the `json` files, we can just run the script. Using the serializers breaks on any referential fields.

Also, this PR makes setting DJANGO_API_TOKEN optional. If the env var is not set, then the imports that require it are skipped.