### PR TITLE
Remove timeout zoom operation

### DIFF
--- a/web/src/views/InvestigationDetail.vue
+++ b/web/src/views/InvestigationDetail.vue
@@ -124,7 +124,6 @@ export default defineComponent({
       await store.dispatch.fetchCurrentInvestigation(props.investigation);
       selectedDataset.value = store.state.activeDataset;
       loaded.value = true;
-      setTimeout(() => zoom(6), 2500);
     });
 
     watch(activeDataset, async (newValue) => {


### PR DESCRIPTION
This PR removes the programmatic zoom action that is triggered 2.5 seconds after loading an investigation.