### PR TITLE
Show pins as list and display on map

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           - 5672:5672
       minio:
         # This image does not require any command arguments (which GitHub Actions don't support)
-        image: bitnami/minio:latest
+        image: bitnami/minio:2022.3.3
         env:
           MINIO_ACCESS_KEY: minioAccessKey
           MINIO_SECRET_KEY: minioSecretKey

--- a/atlascope/core/management/commands/populate.py
+++ b/atlascope/core/management/commands/populate.py
@@ -3,8 +3,8 @@ import os
 from pathlib import Path
 
 from django.contrib.gis.db.models import PointField, PolygonField
-from django.contrib.gis.geos.polygon import Polygon
 from django.contrib.gis.geos import Point
+from django.contrib.gis.geos.polygon import Polygon
 import djclick as click
 from rest_framework.serializers import ValidationError
 

--- a/atlascope/core/management/commands/populate.py
+++ b/atlascope/core/management/commands/populate.py
@@ -2,7 +2,6 @@ import json
 import os
 from pathlib import Path
 
-from django.contrib.auth.models import User
 from django.contrib.gis.db.models import PointField, PolygonField
 from django.contrib.gis.geos.polygon import Polygon
 from django.contrib.gis.geos import Point

--- a/atlascope/core/management/commands/populate.py
+++ b/atlascope/core/management/commands/populate.py
@@ -2,12 +2,14 @@ import json
 import os
 from pathlib import Path
 
-from django.contrib.gis.db.models import PolygonField
+from django.contrib.auth.models import User
+from django.contrib.gis.db.models import PointField, PolygonField
 from django.contrib.gis.geos.polygon import Polygon
+from django.contrib.gis.geos import Point
 import djclick as click
 from rest_framework.serializers import ValidationError
 
-from atlascope.core.models import Dataset, DatasetEmbedding, Investigation, Job
+from atlascope.core.models import Dataset, DatasetEmbedding, Investigation, Job, Pin
 
 POPULATE_DIR = 'atlascope/core/management/populate/'
 
@@ -16,6 +18,7 @@ MODEL_JSON_MAPPING = [
     (Investigation, 'investigations.json'),
     (DatasetEmbedding, 'embeddings.json'),
     (Job, 'jobs.json'),
+    (Pin, 'pins.json'),
 ]
 
 
@@ -36,6 +39,8 @@ def expand_references(obj, model):
             }
         elif isinstance(found_field, PolygonField):
             obj[field_name] = Polygon.from_bbox(tuple(value))
+        elif isinstance(found_field, PointField):
+            obj[field_name] = Point((value['x'], value['y']))
         found_many_to_many = [
             field for field in model._meta.many_to_many if field.name == field_name
         ]

--- a/atlascope/core/management/populate/pins.json
+++ b/atlascope/core/management/populate/pins.json
@@ -1,0 +1,32 @@
+[
+    {
+        "investigation": "Whole Team Investigation",
+        "parent": "Local Vandy Dataset",
+        "child_location": {
+            "x": 1000,
+            "y": 1000
+        },
+        "note": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam non pulvinar turpis. Suspendisse et elit et nisi imperdiet sodales. Integer aliquet sodales mi a vulputate. Pellentesque ut mi faucibus, dictum ex a, imperdiet metus. Cras sed ipsum a lacus placerat pulvinar. Donec tincidunt velit bibendum velit eleifend, ut volutpat lorem feugiat.",
+        "color": "red"
+    },
+    {
+        "investigation": "Whole Team Investigation",
+        "parent": "Local Vandy Dataset",
+        "child_location": {
+            "x": 3000,
+            "y": 1000
+        },
+        "note": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam non pulvinar turpis. Suspendisse et elit et nisi imperdiet sodales. Integer aliquet sodales mi a vulputate. Pellentesque ut mi faucibus, dictum ex a, imperdiet metus. Cras sed ipsum a lacus placerat pulvinar. Donec tincidunt velit bibendum velit eleifend, ut volutpat lorem feugiat.",
+        "color": "green"
+    },
+    {
+        "investigation": "Whole Team Investigation",
+        "parent": "Local Vandy Dataset",
+        "child_location": {
+            "x": 2000,
+            "y": 2000
+        },
+        "note": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam non pulvinar turpis. Suspendisse et elit et nisi imperdiet sodales. Integer aliquet sodales mi a vulputate. Pellentesque ut mi faucibus, dictum ex a, imperdiet metus. Cras sed ipsum a lacus placerat pulvinar. Donec tincidunt velit bibendum velit eleifend, ut volutpat lorem feugiat.",
+        "color": "blue"
+    }
+]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
   minio:
     logging:
       driver: none
-    image: minio/minio:latest
+    image: bitnami/minio:2022.3.3
     command: ["server", "/data", "--console-address", ":${DOCKER_MINIO_CONSOLE_PORT-9001}"]
     environment:
       MINIO_ROOT_USER: minioAccessKey

--- a/web/src/components/InvestigationSidebar.vue
+++ b/web/src/components/InvestigationSidebar.vue
@@ -3,29 +3,27 @@
     max-width="33vw"
     min-width="33vw"
   >
-    <v-expansion-panels
-      accordian
-      flat
+    <v-tabs
+      centered
+      grow
     >
-      <v-expansion-panel>
-        <v-expansion-panel-header>
-          Pins
-        </v-expansion-panel-header>
-        <v-expansion-panel-content>
-          <pin-list />
-        </v-expansion-panel-content>
-      </v-expansion-panel>
-      <v-expansion-panel>
-        <v-expansion-panel-header>
-          Metadata
-        </v-expansion-panel-header>
-        <v-expansion-panel-content>
+      <v-tab>
+        Pins
+      </v-tab>
+      <v-tab-item>
+        <pin-list />
+      </v-tab-item>
+      <v-tab>
+        Metadata
+      </v-tab>
+      <v-tab-item>
+        <div class="ma-2 pa-2">
           <span class="metadata">
             {{ investigationMetadata }}
           </span>
-        </v-expansion-panel-content>
-      </v-expansion-panel>
-    </v-expansion-panels>
+        </div>
+      </v-tab-item>
+    </v-tabs>
   </v-sheet>
 </template>
 

--- a/web/src/components/PinList.vue
+++ b/web/src/components/PinList.vue
@@ -1,35 +1,66 @@
 <template>
   <v-list
+    three-line
     dense
     flat
-    class="pa-0 ma-0"
+    class="ma-0 pa-0"
   >
-    <v-list-item-group v-model="selectedItem">
+    <v-list-item-group
+      v-model="selectedPins"
+      multiple
+      @change="selectionChanged"
+    >
       <v-list-item
         v-for="pin in pins"
         :key="pin.id"
+        :value="pin"
       >
-        <v-list-item-icon>
-          <v-icon :color="pin.color">
-            mdi-circle
-          </v-icon>
-        </v-list-item-icon>
-        <v-list-item-content>
-          {{ pin.id }}
-        </v-list-item-content>
+        <template v-slot:default="{ active }">
+          <v-list-item-action>
+            <v-checkbox :input-value="active" />
+          </v-list-item-action>
+          <v-list-item-content>
+            <v-list-item-title>{{ pinDisplayTitle(pin) }}</v-list-item-title>
+            <v-list-item-subtitle>{{ pin.note }}</v-list-item-subtitle>
+          </v-list-item-content>
+        </template>
       </v-list-item>
     </v-list-item-group>
   </v-list>
 </template>
 
 <script lang="ts">
-import { computed, defineComponent } from '@vue/composition-api';
+import {
+  computed, defineComponent, onMounted, Ref, ref,
+} from '@vue/composition-api';
 import store from '../store';
+import { Pin } from '../generatedTypes/AtlascopeTypes';
 
 export default defineComponent({
   setup() {
-    const pins = computed(() => store.getters.pins);
-    return { pins };
+    const pins: Ref<Pin[]> = computed(() => store.state.currentPins);
+    const selectedPins: Ref<Pin[]> = ref([]);
+    function selectionChanged(pinList: Pin[]) {
+      store.dispatch.updateSelectedPins(pinList);
+    }
+
+    function pinDisplayTitle(pin: Pin) {
+      return (!pin.child) ? `Note pin: ${pin.note?.substring(0, 25)}...` : `Child dataset: ${pin.child}`;
+    }
+
+    onMounted(() => {
+      // reset selectedPins
+      store.state.selectedPins.forEach((pin) => {
+        selectedPins.value.push(pin);
+      });
+    });
+
+    return {
+      pins,
+      selectionChanged,
+      selectedPins,
+      pinDisplayTitle,
+    };
   },
 });
 </script>

--- a/web/src/store/index.ts
+++ b/web/src/store/index.ts
@@ -4,7 +4,7 @@ import { createDirectStore } from 'direct-vuex';
 
 import { AxiosInstance, AxiosResponse } from 'axios';
 import {
-  User, Investigation, InvestigationDetail, Dataset, TileMetadata, Pin,
+  Investigation, InvestigationDetail, Dataset, TileMetadata, Pin,
 } from '../generatedTypes/AtlascopeTypes';
 
 Vue.use(Vuex);

--- a/web/src/store/index.ts
+++ b/web/src/store/index.ts
@@ -4,7 +4,7 @@ import { createDirectStore } from 'direct-vuex';
 
 import { AxiosInstance, AxiosResponse } from 'axios';
 import {
-  Investigation, InvestigationDetail, Dataset, TileMetadata,
+  User, Investigation, InvestigationDetail, Dataset, TileMetadata, Pin,
 } from '../generatedTypes/AtlascopeTypes';
 
 Vue.use(Vuex);
@@ -15,6 +15,8 @@ export interface State {
     currentInvestigation: InvestigationDetail | null;
     currentDatasets: Dataset[];
     activeDataset: Dataset | null;
+    currentPins: Pin[];
+    selectedPins: Pin[];
 }
 
 const {
@@ -30,6 +32,8 @@ const {
     currentInvestigation: null,
     currentDatasets: [],
     activeDataset: null,
+    currentPins: [],
+    selectedPins: [],
   } as State,
   mutations: {
     setInvestigations(state, investigations: Investigation[]) {
@@ -47,28 +51,14 @@ const {
     setActiveDataset(state, dataset: Dataset | null) {
       state.activeDataset = dataset;
     },
+    setCurrentPins(state, pins: Pin[]) {
+      state.currentPins = pins;
+    },
+    setSelectedPins(state, pins: Pin[]) {
+      state.selectedPins = pins;
+    },
   },
   getters: {
-    pins(state: State): any[] {
-      if (state.currentInvestigation !== null) {
-        // Use placeholders until GET /pins is implemented
-        return [
-          {
-            id: 'pin_1',
-            dataset: null,
-            color: 'red',
-            note: 'I am only a test pin.',
-          },
-          {
-            id: 'pin_2',
-            dataset: null,
-            color: 'green',
-            note: 'I am also just a test pin.',
-          },
-        ];
-      }
-      return [];
-    },
     tilesourceDatasets(state: State): Dataset[] {
       return state.currentDatasets.filter((dataset) => dataset.dataset_type === 'tile_source');
     },
@@ -103,6 +93,9 @@ const {
           const tileSourceDatasets = datasets.filter((dataset: Dataset) => dataset.dataset_type === 'tile_source');
           const activeDataset = tileSourceDatasets.length > 0 ? tileSourceDatasets[0] : null;
           commit.setActiveDataset(activeDataset);
+
+          const pins = (await store.state.axiosInstance.get(`/investigations/${investigationId}/pins`)).data;
+          commit.setCurrentPins(pins);
         }
       } else {
         commit.setCurrentInvestigation(null);
@@ -117,6 +110,10 @@ const {
     setActiveDataset(context, dataset: Dataset | null) {
       const { commit } = rootActionContext(context);
       commit.setActiveDataset(dataset);
+    },
+    updateSelectedPins(context, pins: Pin[]) {
+      const { commit } = rootActionContext(context);
+      commit.setSelectedPins(pins);
     },
     async fetchDatasetMetadata(_context, datasetId: string): Promise<TileMetadata | null> {
       if (store.state.axiosInstance) {

--- a/web/src/utilities/useGeoJS.ts
+++ b/web/src/utilities/useGeoJS.ts
@@ -37,6 +37,13 @@ export default function useGeoJS(element: Ref<HTMLElement | null>) {
     }
   };
 
+  const clampBoundsX = (value: boolean): boolean | undefined => {
+    if (map.value) {
+      return map.value.clampBoundsX(value);
+    }
+    return undefined;
+  };
+
   const exit = () => {
     map.value.exit();
   };
@@ -50,6 +57,8 @@ export default function useGeoJS(element: Ref<HTMLElement | null>) {
     const layer = map.value.createLayer(layerType, layerParams);
     return layer;
   };
+
+  const geoEvents = geo.event;
 
   const generatePixelCoordinateParams = (
     width: number,
@@ -75,5 +84,7 @@ export default function useGeoJS(element: Ref<HTMLElement | null>) {
     createMap,
     createLayer,
     generatePixelCoordinateParams,
+    geoEvents,
+    clampBoundsX,
   };
 }

--- a/web/src/utilities/utiltyFunctions.ts
+++ b/web/src/utilities/utiltyFunctions.ts
@@ -1,0 +1,19 @@
+export interface Point {
+  x: number;
+  y: number;
+}
+
+export function postGisToPoint(location: string): Point | undefined {
+  try {
+    const stringParts = location.split(' ');
+    const xPart = stringParts[1];
+    const yPart = stringParts[2];
+    return {
+      x: parseInt(xPart.substring(1), 10),
+      y: parseInt(yPart.substring(0, yPart.length - 1), 10),
+    };
+  } catch (error) {
+    console.error(`Failed to convert location to point ${error}`);
+  }
+  return undefined;
+}

--- a/web/src/views/InvestigationDetail.vue
+++ b/web/src/views/InvestigationDetail.vue
@@ -39,7 +39,19 @@
           <div
             ref="map"
             class="map"
-          />
+          >
+            <v-menu
+              v-model="showNote"
+              :position-x="noteX"
+              :position-y="noteY"
+              absolute
+              offset-y
+            >
+              <v-card class="pin-hover-card">
+                {{ hoverText }}
+              </v-card>
+            </v-menu>
+          </div>
         </v-sheet>
       </v-col>
       <v-col
@@ -75,6 +87,10 @@
     padding: 0;
     margin: 0;
 }
+
+.pin-hover-card {
+  width: 500px;
+}
 </style>
 
 <script lang="ts">
@@ -102,12 +118,21 @@ export default defineComponent({
   },
 
   setup(props) {
-    const map = ref(null);
+    const map: Ref<null | HTMLElement> = ref(null);
     const {
-      clampBoundsX, exit, generatePixelCoordinateParams, createMap, createLayer, geoEvents,
+      clampBoundsX,
+      exit,
+      generatePixelCoordinateParams,
+      createMap,
+      createLayer,
+      geoEvents,
     } = useGeoJS(map);
     const loaded = ref(false);
     const sidebarCollapsed = ref(true);
+    const showNote = ref(false);
+    const noteX = ref(0);
+    const noteY = ref(0);
+    const hoverText = ref('');
 
     function toggleSidebar() {
       sidebarCollapsed.value = !sidebarCollapsed.value;
@@ -183,12 +208,16 @@ export default defineComponent({
           })
           .draw();
         pinFeature.geoOn(geoEvents.feature.mouseon, (event: any) => {
-          console.log({ event, on: 'on' });
-          // show tooltip by mouse
+          if (!map.value) { return; }
+          showNote.value = true;
+          noteX.value = event.mouse.page.x;
+          noteY.value = event.mouse.page.y;
+          hoverText.value = event.data.note;
         });
         pinFeature.geoOn(geoEvents.feature.mouseoff, (event: any) => {
-          console.log({ event, on: 'off' });
-          // remove tooltip
+          if (!map.value) { return; }
+          showNote.value = false;
+          hoverText.value = '';
         });
       } else {
         pinFeature.data(pinFeatureData).draw();
@@ -204,6 +233,10 @@ export default defineComponent({
     return {
       loaded,
       sidebarCollapsed,
+      showNote,
+      noteX,
+      noteY,
+      hoverText,
       toggleSidebar,
       map,
       tilesourceDatasets,

--- a/web/src/views/InvestigationDetail.vue
+++ b/web/src/views/InvestigationDetail.vue
@@ -178,8 +178,10 @@ export default defineComponent({
 
     // #region pin
     const selectedPins: Ref<Pin[]> = computed(() => store.state.selectedPins);
+    /* eslint-disable */
     let featureLayer: any;
     let pinFeature: any;
+    /* eslint-enable */
     watch(selectedPins, (pinList) => {
       if (!featureLayer) {
         featureLayer = createLayer('feature', { features: ['point', 'line', 'polygon'] });
@@ -197,6 +199,7 @@ export default defineComponent({
         };
       });
       if (!pinFeature) {
+        /* eslint-disable */
         pinFeature = featureLayer.createFeature('point')
           .data(pinFeatureData)
           .position((pin: any) => ({ x: pin.x, y: pin.y }))
@@ -222,6 +225,7 @@ export default defineComponent({
       } else {
         pinFeature.data(pinFeatureData).draw();
       }
+      /* eslint-enable */
     });
     // #endregion pin
     onMounted(async () => {

--- a/web/src/views/InvestigationDetail.vue
+++ b/web/src/views/InvestigationDetail.vue
@@ -204,7 +204,6 @@ export default defineComponent({
           .data(pinFeatureData)
           .position((pin: any) => ({ x: pin.x, y: pin.y }))
           .style({
-            // reasonable default?
             radius: 10,
             strokeColor: 'white',
             fillColor: (pin: any) => pin.color,

--- a/web/src/views/InvestigationDetail.vue
+++ b/web/src/views/InvestigationDetail.vue
@@ -138,7 +138,6 @@ export default defineComponent({
       sidebarCollapsed.value = !sidebarCollapsed.value;
     }
 
-    // #region datasets
     const selectedDataset: Ref<Dataset | null> = ref(null);
     const activeDataset = computed(() => store.state.activeDataset);
     const tilesourceDatasets = computed(() => store.getters.tilesourceDatasets);
@@ -174,9 +173,7 @@ export default defineComponent({
       createLayer('osm', geojsParams.layer);
       clampBoundsX(false);
     });
-    // #endregion datasets
 
-    // #region pin
     const selectedPins: Ref<Pin[]> = computed(() => store.state.selectedPins);
     /* eslint-disable */
     let featureLayer: any;
@@ -223,7 +220,7 @@ export default defineComponent({
       }
       /* eslint-enable */
     });
-    // #endregion pin
+
     onMounted(async () => {
       await store.dispatch.fetchCurrentInvestigation(props.investigation);
       selectedDataset.value = store.state.activeDataset;

--- a/web/src/views/InvestigationDetail.vue
+++ b/web/src/views/InvestigationDetail.vue
@@ -187,10 +187,7 @@ export default defineComponent({
         featureLayer = createLayer('feature', { features: ['point', 'line', 'polygon'] });
       }
       const pinFeatureData = pinList.map((pin) => {
-        let pinLocation: Point | undefined = postGisToPoint(pin.child_location);
-        if (!pinLocation) {
-          pinLocation = { x: 0, y: 0 };
-        }
+        const pinLocation: Point = postGisToPoint(pin.child_location) || { x: 0, y: 0 };
         return {
           ...pinLocation,
           id: pin.id,


### PR DESCRIPTION
This PR adds some basic functionality to pins. To demonstrate the UI changes, three pin objects are created with the `populate` command. These pins just contain notes and do not point to child dataset objects.

To test these changes, run the populate script to ensure you have these pins. In front-end application, navigate to the `InvestigationDetail` view for the "Whole Team Investigation." In the sidebar you should see a `Pins` tab, which lists all pins for the investigation, including the three pins added to the populate script as part of these changes. Click the checkbox next to any of these pins to toggle a geojs feature for that pin. It should display with the pin's color. This can be checked from the admin console.

Hover over the pin on the geojs map. The note should appear at your mouse. Moving the mouse outside of the pin will cause the note to disappear again.

Test selecting/deselecting pins in the sidebar. Test collapsing/un-collapsing the sidebar. For all of these tasks, verify that the selected pins in the sidebar reflect the pins shown on the map.

These changes relate to #71 and #92, but does not fully address those issues. 