### PR TITLE
Improve subimage ergonomics

### DIFF
--- a/atlascope/core/models/dataset.py
+++ b/atlascope/core/models/dataset.py
@@ -114,9 +114,7 @@ class DatasetSubImageSerializer(serializers.Serializer):
     y1 = serializers.IntegerField(required=True)
 
     def validate_original_dataset_id(self, value):
-        if not Dataset.objects.filter(id=value).exists():
-            raise ValidationError(f'{value} does not exist. Must use existing dataset')
-        return str(value)
+        return Dataset.objects.get(id=value)
 
 
 @admin.register(Dataset)

--- a/atlascope/core/models/dataset.py
+++ b/atlascope/core/models/dataset.py
@@ -43,6 +43,24 @@ class Dataset(TimeStampedModel, models.Model):
         if not self.name:
             self.name = importer_obj.dataset_name or f'{importer} {self.id}'
 
+    def subimage(self, x0: int, x1: int, y0: int, y1: int) -> 'Dataset':
+        metadata = {
+            'x0': x0,
+            'x1': x1,
+            'y0': y0,
+            'y1': y1,
+        }
+
+        dataset = Dataset(
+            name=f'{self.name} Subimage ({x0}, {y0}) -> ({x1}, {y1})',
+            metadata=metadata,
+            source_dataset=self,
+            content=self.content,
+            dataset_type="subimage"
+        )
+
+        return dataset
+
 
 class DatasetSerializer(serializers.ModelSerializer):
     class Meta:

--- a/atlascope/core/models/dataset.py
+++ b/atlascope/core/models/dataset.py
@@ -124,15 +124,10 @@ class DatasetCreateSerializer(serializers.ModelSerializer):
 
 
 class DatasetSubImageSerializer(serializers.Serializer):
-
-    original_dataset_id = serializers.UUIDField(required=True)
     x0 = serializers.IntegerField(required=True)
     y0 = serializers.IntegerField(required=True)
     x1 = serializers.IntegerField(required=True)
     y1 = serializers.IntegerField(required=True)
-
-    def validate_original_dataset_id(self, value):
-        return Dataset.objects.get(id=value)
 
 
 @admin.register(Dataset)

--- a/atlascope/core/models/dataset.py
+++ b/atlascope/core/models/dataset.py
@@ -56,7 +56,7 @@ class Dataset(TimeStampedModel, models.Model):
             metadata=metadata,
             source_dataset=self,
             content=self.content,
-            dataset_type="subimage"
+            dataset_type="subimage",
         )
 
         return dataset

--- a/atlascope/core/rest/endpoints/dataset_endpoints.py
+++ b/atlascope/core/rest/endpoints/dataset_endpoints.py
@@ -39,15 +39,13 @@ class DatasetViewSet(
         return Response(DatasetSerializer(new_dataset_obj).data, status=status.HTTP_201_CREATED)
 
     @swagger_auto_schema(request_body=DatasetSubImageSerializer())
-    @action(detail=False, methods=['POST'])
-    def subimage(self, request):
+    @action(detail=True, methods=['POST'])
+    def subimage(self, request, pk):
         serializer = DatasetSubImageSerializer(data=self.request.data)
         serializer.is_valid(raise_exception=True)
 
-        original_dataset = serializer.validated_data["original_dataset_id"]
-        serializer.validated_data.pop("original_dataset_id")
+        original = Dataset.objects.get(id=pk)
+        subimage = original.subimage(**serializer.validated_data)
+        subimage.save()
 
-        new_dataset_obj = original_dataset.subimage(**serializer.validated_data)
-        new_dataset_obj.save()
-
-        return Response(DatasetSerializer(new_dataset_obj).data, status=status.HTTP_201_CREATED)
+        return Response(DatasetSerializer(subimage).data, status=status.HTTP_201_CREATED)

--- a/atlascope/core/rest/endpoints/dataset_endpoints.py
+++ b/atlascope/core/rest/endpoints/dataset_endpoints.py
@@ -44,7 +44,7 @@ class DatasetViewSet(
         serializer = DatasetSubImageSerializer(data=self.request.data)
         serializer.is_valid(raise_exception=True)
 
-        original = Dataset.objects.get(id=pk)
+        original = self.get_object()
         subimage = original.subimage(**serializer.validated_data)
         subimage.save()
 

--- a/atlascope/core/rest/endpoints/dataset_endpoints.py
+++ b/atlascope/core/rest/endpoints/dataset_endpoints.py
@@ -43,15 +43,11 @@ class DatasetViewSet(
     def subimage(self, request):
         serializer = DatasetSubImageSerializer(data=self.request.data)
         serializer.is_valid(raise_exception=True)
-        original_dataset = Dataset.objects.get(id=serializer.validated_data["original_dataset_id"])
-        meta = serializer.validated_data.copy()
-        meta.pop("original_dataset_id")
-        new_dataset_obj = Dataset(
-            name=f'{original_dataset.name} Subimage',
-            metadata=meta,
-            source_dataset=original_dataset,
-            dataset_type="subimage",
-        )
+
+        original_dataset = serializer.validated_data["original_dataset_id"]
+        serializer.validated_data.pop("original_dataset_id")
+
+        new_dataset_obj = original_dataset.subimage(**serializer.validated_data)
         new_dataset_obj.save()
 
         return Response(DatasetSerializer(new_dataset_obj).data, status=status.HTTP_201_CREATED)

--- a/atlascope/tests/test_core_endpoints.py
+++ b/atlascope/tests/test_core_endpoints.py
@@ -76,8 +76,10 @@ def test_retrieve_dataset(api_client, dataset_factory):
 
 @pytest.mark.django_db
 def test_subimage(api_client, dataset_factory):
-    test_data = {"original_dataset_id": dataset_factory().id, "x0": 1, "x1": 2, "y0": 3, "y1": 4}
-    resp = api_client().post('/api/v1/datasets/subimage', data=test_data)
+    test_data = {"x0": 1, "x1": 2, "y0": 3, "y1": 4}
+    id = dataset_factory().id
+
+    resp = api_client().post(f'/api/v1/datasets/{id}/subimage', data=test_data)
     assert resp.status_code == 201
 
 


### PR DESCRIPTION
This PR makes the following attempted improvements to the subimage infrastructure:
- move the subimage creation machinery to the `Dataset` model (and access it therefrom in the associated endpoint)
- make the endpoint operate on a specific `Dataset`

This has two basic effects:
1. It allows for easier creation of subimage datasets in the populate script.
2. It simplifies the serializer used to create subimages.

@marySalvi, please let me know if this is a valid improvement on the subimage machinery.
@annehaley, please advise on whether this is good Django practice.

~(This PR depends on #99; merging that PR will make the diff for this one much easier to digest.)~ #99 has been merged.