### PR TITLE
Add "embeddings" endpoint

### DIFF
--- a/atlascope/core/models/dataset_embedding.py
+++ b/atlascope/core/models/dataset_embedding.py
@@ -30,6 +30,14 @@ class DatasetEmbedding(models.Model):
 
 
 class DatasetEmbeddingSerializer(serializers.ModelSerializer):
+    child_bounding_box = serializers.ListField(
+        source='child_bounding_box.extent',
+        child=serializers.FloatField(),
+        min_length=4,
+        max_length=4,
+        read_only=True,
+    )
+
     class Meta:
         model = DatasetEmbedding
         fields = '__all__'

--- a/atlascope/core/rest/endpoints/dataset_endpoints.py
+++ b/atlascope/core/rest/endpoints/dataset_endpoints.py
@@ -7,6 +7,7 @@ from rest_framework.viewsets import GenericViewSet
 from atlascope.core.models import (
     Dataset,
     DatasetCreateSerializer,
+    DatasetEmbeddingSerializer,
     DatasetSerializer,
     DatasetSubImageSerializer,
 )
@@ -49,3 +50,9 @@ class DatasetViewSet(
         subimage.save()
 
         return Response(DatasetSerializer(subimage).data, status=status.HTTP_201_CREATED)
+
+    @swagger_auto_schema(responses={200: DatasetEmbeddingSerializer(many=True)})
+    @action(detail=True, methods=['GET'])
+    def embeddings(self, request, pk=None):
+        payload = DatasetEmbeddingSerializer(self.get_object().embeddings.all(), many=True).data
+        return Response(payload, status=status.HTTP_200_OK)


### PR DESCRIPTION
This PR adds an endpoint to receive the embeddings adjacency list for an investigation.

- Adds `/investigations/{id}/embeddings`
- Changes the `child_bounding_box` serializer field to return list of its bounding box coordinates