### PR TITLE
Move embeddings endpoint

### DIFF
--- a/atlascope/core/rest/endpoints/dataset_endpoints.py
+++ b/atlascope/core/rest/endpoints/dataset_endpoints.py
@@ -7,7 +7,6 @@ from rest_framework.viewsets import GenericViewSet
 from atlascope.core.models import (
     Dataset,
     DatasetCreateSerializer,
-    DatasetEmbeddingSerializer,
     DatasetSerializer,
     DatasetSubImageSerializer,
 )

--- a/atlascope/core/rest/endpoints/dataset_endpoints.py
+++ b/atlascope/core/rest/endpoints/dataset_endpoints.py
@@ -50,9 +50,3 @@ class DatasetViewSet(
         subimage.save()
 
         return Response(DatasetSerializer(subimage).data, status=status.HTTP_201_CREATED)
-
-    @swagger_auto_schema(responses={200: DatasetEmbeddingSerializer(many=True)})
-    @action(detail=True, methods=['GET'])
-    def embeddings(self, request, pk=None):
-        payload = DatasetEmbeddingSerializer(self.get_object().embeddings.all(), many=True).data
-        return Response(payload, status=status.HTTP_200_OK)

--- a/atlascope/core/rest/endpoints/investigation_endpoints.py
+++ b/atlascope/core/rest/endpoints/investigation_endpoints.py
@@ -5,6 +5,7 @@ from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
 from atlascope.core.models import (
+    DatasetEmbeddingSerializer,
     Investigation,
     InvestigationSerializer,
     JobDetailSerializer,

--- a/atlascope/core/rest/endpoints/investigation_endpoints.py
+++ b/atlascope/core/rest/endpoints/investigation_endpoints.py
@@ -31,3 +31,9 @@ class InvestigationViewSet(
     def jobs(self, request, pk=None):
         payload = JobDetailSerializer(self.get_object().jobs.all(), many=True).data
         return Response(payload, status=status.HTTP_200_OK)
+
+    @swagger_auto_schema(responses={200: DatasetEmbeddingSerializer(many=True)})
+    @action(detail=True, methods=['GET'])
+    def embeddings(self, request, pk=None):
+        payload = DatasetEmbeddingSerializer(self.get_object().embeddings.all(), many=True).data
+        return Response(payload, status=status.HTTP_200_OK)


### PR DESCRIPTION
The endpoint was accidentally at `/datasets/{id}/embeddings`. This moves it to the intended location at `/investigations/{id}/embeddings`.