### PR TITLE
Modify tile endpoints to accept `channels` and `colors` querystring args

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
             `# GEOS library development files (GeoDjango)` \
             libgeos-dev \
             `# TIFF reading` \
-            libtiff5-dev
+            libtiff-dev
         shell: bash
       - uses: actions/checkout@v2
       - name: Install tox

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,9 @@ jobs:
             `# PROJ development files and binary (GeoDjango)` \
             libproj-dev proj-bin proj-data \
             `# GEOS library development files (GeoDjango)` \
-            libgeos-dev
+            libgeos-dev \
+            `# TIFF reading` \
+            libtiff5-dev
         shell: bash
       - uses: actions/checkout@v2
       - name: Install tox

--- a/atlascope/core/rest/additional_serializers.py
+++ b/atlascope/core/rest/additional_serializers.py
@@ -24,5 +24,10 @@ class TileMetadataSerializer(serializers.Serializer):
         help_text='Size of the square tiles the image is composed of.',
         min_value=1,
         read_only=True,
-        source='tileSize',
+        source='tileWidth',
+    )
+    metadata = serializers.JSONField(
+        help_text='Any additional metadata on the tile source.',
+        read_only=True,
+        source='getMetadata',
     )

--- a/atlascope/core/rest/additional_serializers.py
+++ b/atlascope/core/rest/additional_serializers.py
@@ -26,7 +26,7 @@ class TileMetadataSerializer(serializers.Serializer):
         read_only=True,
         source='tileWidth',
     )
-    metadata = serializers.JSONField(
+    additional_metadata = serializers.JSONField(
         help_text='Any additional metadata on the tile source.',
         read_only=True,
         source='getMetadata',

--- a/atlascope/core/rest/endpoints/tile_endpoints.py
+++ b/atlascope/core/rest/endpoints/tile_endpoints.py
@@ -112,9 +112,11 @@ class TileView(GenericAPIView, mixins.RetrieveModelMixin):
                 channels = channels.split(',')
             else:
                 channels = range(len(tile_source.getMetadata()['frames']))
-            colors = self.request.query_params.get('colors').split(',') or range(
-                self.default_colors
-            )
+            colors = self.request.query_params.get('colors')
+            if colors:
+                colors = [f'#{color}' for color in colors.split(',')]
+            else:
+                colors = self.default_colors
             composite = None
             for channel, color in list(zip(channels, colors)):
                 tile = tile_source.getTile(
@@ -126,7 +128,7 @@ class TileView(GenericAPIView, mixins.RetrieveModelMixin):
                 tile_data = numpy.array(PIL.Image.open(io.BytesIO(tile)))
                 if not composite:
                     composite = PIL.Image.new('RGBA', tile_data.shape, '#000000')
-                mask_color = PIL.Image.new('RGBA', tile_data.shape, f'#{color}')
+                mask_color = PIL.Image.new('RGBA', tile_data.shape, color)
                 mask = PIL.Image.fromarray(tile_data)
                 composite = PIL.Image.composite(mask_color, composite, mask)
             buf = io.BytesIO()

--- a/atlascope/core/rest/endpoints/tile_endpoints.py
+++ b/atlascope/core/rest/endpoints/tile_endpoints.py
@@ -1,8 +1,7 @@
-import fsspec
-
 from django.urls import path
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
+import fsspec
 from large_image.exceptions import TileSourceError
 from large_image_source_ometiff import OMETiffFileTileSource
 from rest_framework import mixins

--- a/atlascope/core/rest/endpoints/tile_endpoints.py
+++ b/atlascope/core/rest/endpoints/tile_endpoints.py
@@ -102,7 +102,7 @@ class TileView(GenericAPIView, mixins.RetrieveModelMixin):
         channels = self.request.query_params.get('channels').split(',') or range(
             len(tile_source.getMetadata()['frames'])
         )
-        colors = self.request.query_params.get('colors').split(',') or range(default_colors)
+        colors = self.request.query_params.get('colors').split(',') or range(self.default_colors)
         try:
             composite = None
             for channel, color in list(zip(channels, colors)):

--- a/atlascope/core/rest/endpoints/tile_endpoints.py
+++ b/atlascope/core/rest/endpoints/tile_endpoints.py
@@ -1,13 +1,13 @@
-import fsspec
 import io
-import numpy
-import PIL
 
+import PIL
 from django.urls import path
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
+import fsspec
 from large_image.exceptions import TileSourceError
 from large_image_source_ometiff import OMETiffFileTileSource
+import numpy
 from rest_framework import mixins
 from rest_framework.exceptions import APIException, NotFound
 from rest_framework.generics import GenericAPIView

--- a/dev/django.Dockerfile
+++ b/dev/django.Dockerfile
@@ -15,6 +15,8 @@ RUN apt-get update \
         libproj-dev proj-bin proj-data \
         # GEOS library development files (GeoDjango)
         libgeos-dev \
+        # TIFF reading
+        libtiff-dev \
         # Nginx to proxy localhost
         nginx \
  && pip install --upgrade pip \

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,10 @@ setup(
         'numpy',
         'pillow',
         'requests',
+        # manual override until https://github.com/girder/large_image/pull/799
+        'pylibtiff',
+        # pylibtiff depends on this but it is not listed in its dependencies
+        'bitarray',
     ],
     extras_require={
         'dev': [

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
+        'aiohttp',
         'celery',
         'django>=3.2,<4.0',
         'django-allauth',
@@ -46,14 +47,16 @@ setup(
         'djangorestframework',
         'drf-yasg',
         'django-click',
+        'fsspec',
         'importlib_metadata>=3.6',
-        'large-image[gdal]',
+        'large-image[gdal,ometiff]',
         # Production-only
         'django-composed-configuration[prod]>=0.18',
         'django-s3-file-field[boto3]',
         'gunicorn',
         'numpy',
         'pillow',
+        'requests',
     ],
     extras_require={
         'dev': [

--- a/web/src/generatedTypes/AtlascopeTypes.ts
+++ b/web/src/generatedTypes/AtlascopeTypes.ts
@@ -105,6 +105,14 @@ export interface TileMetadata {
    * @min 1
    */
   tile_size?: number;
+
+  /**
+   * Additional metadata
+   * Any additional metadata from the tile source.
+   */
+  additional_metadata: {
+    frames: Array<Record<string, string>>;
+  }
 }
 
 export interface Investigation {

--- a/web/src/views/InvestigationDetail.vue
+++ b/web/src/views/InvestigationDetail.vue
@@ -166,8 +166,9 @@ export default defineComponent({
       if (!geojsParams || !geojsParams.map || !geojsParams.layer) {
         return;
       }
+      // console.log(tileSourceMetadata.additional_metadata.frames);
       const apiRoot = process.env.VUE_APP_API_ROOT;
-      const queryString = '?channels=0,1,2&colors=eb4034,33a61c,1c6aa6';
+      const queryString = '?channels=1,2,3&colors=cf1dae,33a61c,58cf1d';
       geojsParams.layer.url = `${apiRoot}/datasets/${newValue.id}/tiles/{z}/{x}/{y}.png${queryString}`;
       geojsParams.layer.crossDomain = 'use-credentials';
 

--- a/web/src/views/InvestigationDetail.vue
+++ b/web/src/views/InvestigationDetail.vue
@@ -167,8 +167,10 @@ export default defineComponent({
         return;
       }
       const apiRoot = process.env.VUE_APP_API_ROOT;
-      geojsParams.layer.url = `${apiRoot}/datasets/${newValue.id}/tiles/{z}/{x}/{y}.png`;
+      const queryString = '?channels=0,1,2&colors=eb4034,33a61c,1c6aa6';
+      geojsParams.layer.url = `${apiRoot}/datasets/${newValue.id}/tiles/{z}/{x}/{y}.png${queryString}`;
       geojsParams.layer.crossDomain = 'use-credentials';
+
       createMap(geojsParams.map);
       createLayer('osm', geojsParams.layer);
       clampBoundsX(false);


### PR DESCRIPTION
This PR uses `fsspec` to locally cache the remote `dataset.content.url` and replaces the `GDALFileTileSource` with `OMETiffFileTileSource`. It may be necessary to use `if` logic and support both.

Supplying the `channel` kwarg to the tile endpoint will return the tile from only the channel corresponding to that index. This will enable us to color and composite the channels on the frontend rather than the backend. The metadata endpoint supplies `metadata.frames`, which describes the channels as they are defined within the TIFF.