### PR TITLE
Fix pin-related bugs

### DIFF
--- a/web/src/components/PinList.vue
+++ b/web/src/components/PinList.vue
@@ -14,10 +14,14 @@
         v-for="pin in pins"
         :key="pin.id"
         :value="pin"
+        :disabled="pin.parent !== activeDataset.id"
       >
         <template v-slot:default="{ active }">
           <v-list-item-action>
-            <v-checkbox :input-value="active" />
+            <v-checkbox
+              :input-value="active"
+              :disabled="pin.parent !== activeDataset.id"
+            />
           </v-list-item-action>
           <v-list-item-content>
             <v-list-item-title>{{ pinDisplayTitle(pin) }}</v-list-item-title>
@@ -62,6 +66,7 @@ export default defineComponent({
 
     return {
       pins,
+      activeDataset,
       selectionChanged,
       selectedPins,
       pinDisplayTitle,

--- a/web/src/components/PinList.vue
+++ b/web/src/components/PinList.vue
@@ -31,7 +31,7 @@
 
 <script lang="ts">
 import {
-  computed, defineComponent, onMounted, Ref, ref,
+  computed, defineComponent, onMounted, Ref, ref, watch,
 } from '@vue/composition-api';
 import store from '../store';
 import { Pin } from '../generatedTypes/AtlascopeTypes';
@@ -39,6 +39,7 @@ import { Pin } from '../generatedTypes/AtlascopeTypes';
 export default defineComponent({
   setup() {
     const pins: Ref<Pin[]> = computed(() => store.state.currentPins);
+    const activeDataset = computed(() => store.state.activeDataset);
     const selectedPins: Ref<Pin[]> = ref([]);
     function selectionChanged(pinList: Pin[]) {
       store.dispatch.updateSelectedPins(pinList);
@@ -47,6 +48,10 @@ export default defineComponent({
     function pinDisplayTitle(pin: Pin) {
       return (!pin.child) ? `Note pin: ${pin.note?.substring(0, 25)}...` : `Child dataset: ${pin.child}`;
     }
+
+    watch(activeDataset, () => {
+      selectedPins.value = [];
+    });
 
     onMounted(() => {
       // reset selectedPins

--- a/web/src/views/InvestigationDetail.vue
+++ b/web/src/views/InvestigationDetail.vue
@@ -141,14 +141,24 @@ export default defineComponent({
     const selectedDataset: Ref<Dataset | null> = ref(null);
     const activeDataset = computed(() => store.state.activeDataset);
     const tilesourceDatasets = computed(() => store.getters.tilesourceDatasets);
+    /* eslint-disable */
+    let featureLayer: any;
+    let pinFeature: any;
+    /* eslint-enable */
 
     function activeDatasetChanged(newActiveDataset: Dataset) {
       selectedDataset.value = newActiveDataset;
       store.dispatch.setActiveDataset(newActiveDataset);
     }
 
-    function drawMap(dataset: Dataset | null) {
+    function tearDownMap() {
       exit();
+      featureLayer = null;
+      pinFeature = null;
+    }
+
+    function drawMap(dataset: Dataset | null) {
+      tearDownMap();
       if (!dataset || !dataset.id) {
         return;
       }
@@ -179,10 +189,6 @@ export default defineComponent({
     });
 
     const selectedPins: Ref<Pin[]> = computed(() => store.state.selectedPins);
-    /* eslint-disable */
-    let featureLayer: any;
-    let pinFeature: any;
-    /* eslint-enable */
     watch(selectedPins, (pinList) => {
       if (!featureLayer) {
         featureLayer = createLayer('feature', { features: ['point', 'line', 'polygon'] });


### PR DESCRIPTION
This PR fixes some bugs that I've observed with the pin list and pin display in the Investigation detail view.

**Pin Selection**
Pin selection is now cleared when the active dataset changes via the drop down. Prior to this change, pins would remain selected, as indicated by the checkbox, even after the dataset being displayed changed. 

**Pin Display**
Feature layer creation is now more consistent. Previously, if the active dataset was changed, the feature layer would remain, but the map it was associated with would be destroyed. The layer would not be associated with the new map that was created as a result of the dataset change. Now, the feature layer is destroyed when the active dataset changes, and a new one is created to show pins on the new dataset.

**Pins Respect Active Dataset**
Now selected pins are filtered based on active dataset before being displayed on the dataset. This works fine for now, but once the embeddings view is merged into the current interation of the `InvestigationDetail` view, we will need a more sophisticated filter (and likely a more sophisticated way to determine location). 
