### PR TITLE
Simplify populate script

### DIFF
--- a/atlascope/core/management/commands/populate.py
+++ b/atlascope/core/management/commands/populate.py
@@ -114,13 +114,39 @@ def populate_datasets(jsonfile):
     print("")
 
 
+def populate_investigations(jsonfile):
+    print("Populating Investigations...")
+
+    # Read in the spec.
+    specs = json.load(open(jsonfile))
+
+    for spec in specs:
+        # Pull out the dataset models that are in the investigation.
+        datasets = [Dataset.objects.get(name=name) for name in spec["datasets"]]
+        del spec["datasets"]
+
+        # Build and save investigation objects.
+        print(f"""  Investigation '{spec["name"]}'""")
+        investigation = Investigation(**spec)
+        investigation.save()
+
+        # Associate the datasets to the investigation.
+        print("    datasets:")
+        for d in datasets:
+            print(f"      {d.name}")
+        investigation.datasets.set(datasets)
+
+    print("")
+
+
 @click.command()
 def command():
     delete_all()
 
     populate_datasets(POPULATE_DIR / 'datasets.json')
+    populate_investigations(POPULATE_DIR / 'investigations.json')
 
-    for model, filename in MODEL_JSON_MAPPING[1:]:
+    for model, filename in MODEL_JSON_MAPPING[2:]:
         print('-----')
         objects = json.load(open(POPULATE_DIR / filename))
         for obj in objects:

--- a/atlascope/core/management/commands/populate.py
+++ b/atlascope/core/management/commands/populate.py
@@ -2,7 +2,6 @@ import json
 import os
 from pathlib import Path
 
-from django.contrib.gis.db.models import PointField, PolygonField
 from django.contrib.gis.geos import Point
 from django.contrib.gis.geos.polygon import Polygon
 import djclick as click
@@ -21,6 +20,7 @@ def announce(msg):
             print("")
 
         return wrapped
+
     return decorator
 
 
@@ -33,9 +33,9 @@ def delete_all():
     print("done")
 
     # Delete the other objects. Go in reverse order of model creation.
-    for Model in [Investigation, DatasetEmbedding, Job, Pin]:
-        print(f"  {Model.__name__} objects...", end="", flush=True)
-        Model.objects.all().delete()
+    for model in [Investigation, DatasetEmbedding, Job, Pin]:
+        print(f"  {model.__name__} objects...", end="", flush=True)
+        model.objects.all().delete()
         print("done")
 
 
@@ -105,7 +105,10 @@ def populate_embeddings(specs):
         spec["child_bounding_box"] = Polygon.from_bbox(tuple(spec["child_bounding_box"]))
 
         # Build and save the DatasetEmbedding object.
-        print(f"""  DatasetEmbedding '{spec["child"].name}' -> '{spec["parent"].name}' ({spec["investigation"].name})""")
+        child = spec["child"].name
+        parent = spec["parent"].name
+        investigation = spec["investigation"].name
+        print(f"""  DatasetEmbedding '{child}' -> '{parent}' ({investigation})""")
         embedding = DatasetEmbedding(**spec)
         embedding.save()
 

--- a/atlascope/core/management/commands/populate.py
+++ b/atlascope/core/management/commands/populate.py
@@ -31,11 +31,8 @@ def delete_all():
     print("")
 
 
-def populate_datasets(jsonfile):
+def populate_datasets(specs):
     print("Populating Datasets...")
-
-    # Read in the spec.
-    specs = json.load(open(jsonfile))
 
     for spec in specs:
         # Separate any importer arguments.
@@ -74,11 +71,8 @@ def populate_datasets(jsonfile):
     print("")
 
 
-def populate_investigations(jsonfile):
+def populate_investigations(specs):
     print("Populating Investigations...")
-
-    # Read in the spec.
-    specs = json.load(open(jsonfile))
 
     for spec in specs:
         # Pull out the dataset models that are in the investigation.
@@ -99,11 +93,8 @@ def populate_investigations(jsonfile):
     print("")
 
 
-def populate_embeddings(jsonfile):
+def populate_embeddings(specs):
     print("Populating dataset embeddings...")
-
-    # Read in the spec.
-    specs = json.load(open(jsonfile))
 
     for spec in specs:
         # Replace the names in the spec with the models they reference.
@@ -120,11 +111,8 @@ def populate_embeddings(jsonfile):
     print("")
 
 
-def populate_jobs(jsonfile):
+def populate_jobs(specs):
     print("Populating jobs...")
-
-    # Read in the spec.
-    specs = json.load(open(jsonfile))
 
     for spec in specs:
         # Pull in the investigation and dataset referenced in the job spec.
@@ -143,11 +131,8 @@ def populate_jobs(jsonfile):
     print("")
 
 
-def populate_pins(jsonfile):
+def populate_pins(specs):
     print("Populating pins...")
-
-    # Read in the spec.
-    specs = json.load(open(jsonfile))
 
     for spec in specs:
         # Pull in foreign models and other objects.
@@ -165,12 +150,16 @@ def populate_pins(jsonfile):
     print("")
 
 
+def get_json(jsonfile):
+    return json.load(open(jsonfile))
+
+
 @click.command()
 def command():
     delete_all()
 
-    populate_datasets(POPULATE_DIR / 'datasets.json')
-    populate_investigations(POPULATE_DIR / 'investigations.json')
-    populate_embeddings(POPULATE_DIR / 'embeddings.json')
-    populate_jobs(POPULATE_DIR / 'jobs.json')
-    populate_pins(POPULATE_DIR / 'pins.json')
+    populate_datasets(get_json(POPULATE_DIR / 'datasets.json'))
+    populate_investigations(get_json(POPULATE_DIR / 'investigations.json'))
+    populate_embeddings(get_json(POPULATE_DIR / 'embeddings.json'))
+    populate_jobs(get_json(POPULATE_DIR / 'jobs.json'))
+    populate_pins(get_json(POPULATE_DIR / 'pins.json'))

--- a/atlascope/core/management/commands/populate.py
+++ b/atlascope/core/management/commands/populate.py
@@ -160,6 +160,29 @@ def populate_embeddings(jsonfile):
     print("")
 
 
+def populate_jobs(jsonfile):
+    print("Populating jobs...")
+
+    # Read in the spec.
+    specs = json.load(open(jsonfile))
+
+    for spec in specs:
+        # Pull in the investigation and dataset referenced in the job spec.
+        spec["investigation"] = Investigation.objects.get(name=spec["investigation"])
+        spec["original_dataset"] = Dataset.objects.get(name=spec["original_dataset"])
+
+        # Build and save the Job object.
+        print(f"""  Job '{spec["job_type"]}' ({spec["investigation"].name})""")
+        job = Job(**spec)
+        job.save()
+
+        print("    spawning job run...", end="", flush=True)
+        job.spawn()
+        print("done")
+
+    print("")
+
+
 @click.command()
 def command():
     delete_all()
@@ -167,8 +190,9 @@ def command():
     populate_datasets(POPULATE_DIR / 'datasets.json')
     populate_investigations(POPULATE_DIR / 'investigations.json')
     populate_embeddings(POPULATE_DIR / 'embeddings.json')
+    populate_jobs(POPULATE_DIR / 'jobs.json')
 
-    for model, filename in MODEL_JSON_MAPPING[3:]:
+    for model, filename in MODEL_JSON_MAPPING[4:]:
         print('-----')
         objects = json.load(open(POPULATE_DIR / filename))
         for obj in objects:

--- a/atlascope/core/management/commands/populate.py
+++ b/atlascope/core/management/commands/populate.py
@@ -10,7 +10,7 @@ from rest_framework.serializers import ValidationError
 
 from atlascope.core.models import Dataset, DatasetEmbedding, Investigation, Job, Pin
 
-POPULATE_DIR = 'atlascope/core/management/populate/'
+POPULATE_DIR = Path('atlascope/core/management/populate/')
 
 MODEL_JSON_MAPPING = [
     (Dataset, 'datasets.json'),
@@ -31,7 +31,7 @@ def expand_references(obj, model):
             remote_model = found_field.remote_field.model
             obj[field_name] = remote_model.objects.get(name=value)
         elif hasattr(found_field, 'upload_to'):
-            target_file = open(Path(POPULATE_DIR, 'inputs', value), 'rb')
+            target_file = open(POPULATE_DIR / 'inputs' / value, 'rb')
             files_to_save[field_name] = {
                 'name': value,
                 'contents': target_file,
@@ -75,7 +75,7 @@ def command():
 
     for model, filename in MODEL_JSON_MAPPING:
         print('-----')
-        objects = json.load(open(POPULATE_DIR + filename))
+        objects = json.load(open(POPULATE_DIR / filename))
         for obj in objects:
             if 'kwargs' in obj:
                 kwargs = obj['kwargs']

--- a/atlascope/core/management/commands/populate.py
+++ b/atlascope/core/management/commands/populate.py
@@ -183,6 +183,28 @@ def populate_jobs(jsonfile):
     print("")
 
 
+def populate_pins(jsonfile):
+    print("Populating pins...")
+
+    # Read in the spec.
+    specs = json.load(open(jsonfile))
+
+    for spec in specs:
+        # Pull in foreign models and other objects.
+        spec["investigation"] = Investigation.objects.get(name=spec["investigation"])
+        spec["parent"] = Dataset.objects.get(name=spec["parent"])
+        if "child" in spec:
+            spec["child"] = Dataset.objects.get(name=spec["child"])
+        spec["child_location"] = Point(spec["child_location"])
+
+        # Build and save the Pin object.
+        print(f"""  Pin '{spec["parent"].name}' ({spec["investigation"].name})""")
+        pin = Pin(**spec)
+        pin.save()
+
+    print("")
+
+
 @click.command()
 def command():
     delete_all()
@@ -191,8 +213,9 @@ def command():
     populate_investigations(POPULATE_DIR / 'investigations.json')
     populate_embeddings(POPULATE_DIR / 'embeddings.json')
     populate_jobs(POPULATE_DIR / 'jobs.json')
+    populate_pins(POPULATE_DIR / 'pins.json')
 
-    for model, filename in MODEL_JSON_MAPPING[4:]:
+    for model, filename in MODEL_JSON_MAPPING[5:]:
         print('-----')
         objects = json.load(open(POPULATE_DIR / filename))
         for obj in objects:

--- a/atlascope/core/management/commands/populate.py
+++ b/atlascope/core/management/commands/populate.py
@@ -139,14 +139,36 @@ def populate_investigations(jsonfile):
     print("")
 
 
+def populate_embeddings(jsonfile):
+    print("Populating dataset embeddings...")
+
+    # Read in the spec.
+    specs = json.load(open(jsonfile))
+
+    for spec in specs:
+        # Replace the names in the spec with the models they reference.
+        spec["investigation"] = Investigation.objects.get(name=spec["investigation"])
+        spec["parent"] = Dataset.objects.get(name=spec["parent"])
+        spec["child"] = Dataset.objects.get(name=spec["child"])
+        spec["child_bounding_box"] = Polygon.from_bbox(tuple(spec["child_bounding_box"]))
+
+        # Build and save the DatasetEmbedding object.
+        print(f"""  DatasetEmbedding '{spec["child"].name}' -> '{spec["parent"].name}' ({spec["investigation"].name})""")
+        embedding = DatasetEmbedding(**spec)
+        embedding.save()
+
+    print("")
+
+
 @click.command()
 def command():
     delete_all()
 
     populate_datasets(POPULATE_DIR / 'datasets.json')
     populate_investigations(POPULATE_DIR / 'investigations.json')
+    populate_embeddings(POPULATE_DIR / 'embeddings.json')
 
-    for model, filename in MODEL_JSON_MAPPING[2:]:
+    for model, filename in MODEL_JSON_MAPPING[3:]:
         print('-----')
         objects = json.load(open(POPULATE_DIR / filename))
         for obj in objects:

--- a/atlascope/core/management/commands/populate.py
+++ b/atlascope/core/management/commands/populate.py
@@ -53,14 +53,26 @@ def expand_references(obj, model):
     return obj, many_to_many_values, files_to_save
 
 
+def delete_all():
+    print("Deleting...")
+
+    # Delete dataset objects.
+    print("  Dataset objects...", end="", flush=True)
+    Dataset.objects.filter(source_dataset__isnull=False).delete()
+    Dataset.objects.all().delete()
+    print("done")
+
+    # Delete the other objects. Go in reverse order of model creation.
+    for Model in [Investigation, DatasetEmbedding, Job, Pin]:
+        print(f"  {Model.__name__} objects...", end="", flush=True)
+        Model.objects.all().delete()
+        print("done")
+
+
 @click.command()
 def command():
-    # delete in reverse order because of dependency protections
-    for model, _ in reversed(MODEL_JSON_MAPPING):
-        if model == Dataset:
-            model.objects.filter(source_dataset__isnull=False).delete()
-        model.objects.all().delete()
-        print(f'Deleted all existing {model.__name__}s.')
+    delete_all()
+
     for model, filename in MODEL_JSON_MAPPING:
         print('-----')
         objects = json.load(open(POPULATE_DIR + filename))

--- a/atlascope/core/management/populate/datasets.json
+++ b/atlascope/core/management/populate/datasets.json
@@ -2,21 +2,17 @@
     {
         "name": "Local Vandy Dataset",
         "description": "This is the test dataset from the VANDY Explorer",
-        "kwargs": {
-            "content": "HTA9_1_BA_F_ROI02.ome.tif"
-        }
+        "content": "HTA9_1_BA_F_ROI02.ome.tif"
     },
     {
         "name": "Local Vandy Dataset (Copy)",
         "description": "This is the test dataset from the VANDY Explorer",
-        "kwargs": {
-            "content": "HTA9_1_BA_F_ROI02.ome.tif"
-        }
+        "content": "HTA9_1_BA_F_ROI02.ome.tif"
     },
     {
         "name": "Remote Vandy Dataset",
         "description": "This is the test dataset from the VANDY Explorer",
-        "kwargs": {
+        "importer": {
             "importer": "VandyImporter",
             "file_id": "60e84a1868f4fe34fc7eef72"
         }
@@ -24,8 +20,6 @@
     {
         "name": "Cells Subimage",
         "description": "This is a screenshot of some green cells",
-        "kwargs": {
-            "content": "green_cell_dataset_selection.png"
-        }
+        "content": "green_cell_dataset_selection.png"
     }
 ]

--- a/atlascope/core/management/populate/pins.json
+++ b/atlascope/core/management/populate/pins.json
@@ -2,30 +2,21 @@
     {
         "investigation": "Whole Team Investigation",
         "parent": "Local Vandy Dataset",
-        "child_location": {
-            "x": 1000,
-            "y": 1000
-        },
+        "child_location": [1000, 1000],
         "note": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam non pulvinar turpis. Suspendisse et elit et nisi imperdiet sodales. Integer aliquet sodales mi a vulputate. Pellentesque ut mi faucibus, dictum ex a, imperdiet metus. Cras sed ipsum a lacus placerat pulvinar. Donec tincidunt velit bibendum velit eleifend, ut volutpat lorem feugiat.",
         "color": "red"
     },
     {
         "investigation": "Whole Team Investigation",
         "parent": "Local Vandy Dataset",
-        "child_location": {
-            "x": 3000,
-            "y": 1000
-        },
+        "child_location": [3000, 1000],
         "note": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam non pulvinar turpis. Suspendisse et elit et nisi imperdiet sodales. Integer aliquet sodales mi a vulputate. Pellentesque ut mi faucibus, dictum ex a, imperdiet metus. Cras sed ipsum a lacus placerat pulvinar. Donec tincidunt velit bibendum velit eleifend, ut volutpat lorem feugiat.",
         "color": "green"
     },
     {
         "investigation": "Whole Team Investigation",
         "parent": "Local Vandy Dataset",
-        "child_location": {
-            "x": 2000,
-            "y": 2000
-        },
+        "child_location": [2000, 2000],
         "note": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam non pulvinar turpis. Suspendisse et elit et nisi imperdiet sodales. Integer aliquet sodales mi a vulputate. Pellentesque ut mi faucibus, dictum ex a, imperdiet metus. Cras sed ipsum a lacus placerat pulvinar. Donec tincidunt velit bibendum velit eleifend, ut volutpat lorem feugiat.",
         "color": "blue"
     }


### PR DESCRIPTION
This PR simplifies and dumbifies the populate script. This has two main effects:
1. It makes it easier to understand and modify
2. It enables us to insert more customized logic for specific kinds of resources that may show up in the future (e.g., subimages)

Note that I have also simplified some of the (implicit) schema used in the JSON files driving the populate script.

Reviewers: please look for anything I may have done here that will break any assumptions needed for populated data to work properly in the app.