### PR TITLE
Sort rest results by id everywhere

### DIFF
--- a/atlascope/core/rest/endpoints/dataset_endpoints.py
+++ b/atlascope/core/rest/endpoints/dataset_endpoints.py
@@ -17,7 +17,7 @@ class DatasetViewSet(
     mixins.RetrieveModelMixin,
     GenericViewSet,
 ):
-    queryset = Dataset.objects.all().order_by('name')
+    queryset = Dataset.objects.all().order_by('id')
     serializer_class = DatasetSerializer
 
     def get_serializer_class(self):

--- a/atlascope/core/rest/endpoints/investigation_endpoints.py
+++ b/atlascope/core/rest/endpoints/investigation_endpoints.py
@@ -18,19 +18,19 @@ class InvestigationViewSet(
     mixins.RetrieveModelMixin,
     GenericViewSet,
 ):
-    queryset = Investigation.objects.all().order_by('name')
+    queryset = Investigation.objects.all().order_by('id')
     serializer_class = InvestigationSerializer
 
     @swagger_auto_schema(responses={200: PinSerializer(many=True)})
     @action(detail=True, methods=['GET'])
     def pins(self, request, pk=None):
-        payload = PinSerializer(self.get_object().pins.all(), many=True).data
+        payload = PinSerializer(self.get_object().pins.all().order_by('id'), many=True).data
         return Response(payload, status=status.HTTP_200_OK)
 
     @swagger_auto_schema(responses={200: JobDetailSerializer(many=True)})
     @action(detail=True, methods=['GET'])
     def jobs(self, request, pk=None):
-        payload = JobDetailSerializer(self.get_object().jobs.all(), many=True).data
+        payload = JobDetailSerializer(self.get_object().jobs.all().order_by('id'), many=True).data
         return Response(payload, status=status.HTTP_200_OK)
 
     @swagger_auto_schema(responses={200: DatasetEmbeddingSerializer(many=True)})

--- a/atlascope/tests/test_core_endpoints.py
+++ b/atlascope/tests/test_core_endpoints.py
@@ -11,8 +11,8 @@ from atlascope.core.job_types import available_job_types
 
 @pytest.mark.django_db
 def test_list_investigations(api_client, investigation_factory):
-    investigations = [investigation_factory() for i in range(3)]
-    investigations.sort(key=lambda i: i.name)
+    investigations = [investigation_factory() for i in range(10)]
+    investigations.sort(key=lambda i: i.id)
     api_client = api_client(investigation=investigations[0])
     expected_results = [models.InvestigationSerializer(i).data for i in (investigations)]
     resp = api_client.get('/api/v1/investigations')
@@ -35,7 +35,8 @@ def test_retrieve_investigation(api_client, investigation_factory):
 
 @pytest.mark.django_db
 def test_get_investigation_pins(api_client, investigation, pin_factory):
-    pin_set = [pin_factory() for i in range(5)]
+    pin_set = [pin_factory() for i in range(10)]
+    pin_set.sort(key=lambda p: p.id)
     investigation.pins.set(pin_set)
     resp = api_client(investigation=investigation).get(
         f'/api/v1/investigations/{investigation.id}/pins'
@@ -50,8 +51,8 @@ def test_get_investigation_pins(api_client, investigation, pin_factory):
 
 @pytest.mark.django_db
 def test_list_datasets(api_client, dataset_factory):
-    datasets = [dataset_factory() for i in range(3)]
-    datasets.sort(key=lambda d: d.name)
+    datasets = [dataset_factory() for i in range(10)]
+    datasets.sort(key=lambda d: d.id)
     api_client = api_client(dataset=datasets[0])
     expected_results = [models.DatasetSerializer(d).data for d in datasets]
     resp = api_client.get('/api/v1/datasets')
@@ -66,20 +67,16 @@ def test_list_datasets(api_client, dataset_factory):
 
 
 @pytest.mark.django_db
-def test_retrieve_dataset(api_client, dataset_factory):
-    dataset = dataset_factory()
-
-    resp = api_client(dataset=dataset).get(f'/api/v1/datasets/{dataset.id}')
+def test_retrieve_dataset(api_client, dataset):
+    resp = api_client().get(f'/api/v1/datasets/{dataset.id}')
     assert resp.status_code == 200
     assert resp.data == models.DatasetSerializer(dataset).data
 
 
 @pytest.mark.django_db
-def test_subimage(api_client, dataset_factory):
+def test_subimage(api_client, dataset):
     test_data = {"x0": 1, "x1": 2, "y0": 3, "y1": 4}
-    id = dataset_factory().id
-
-    resp = api_client().post(f'/api/v1/datasets/{id}/subimage', data=test_data)
+    resp = api_client().post(f'/api/v1/datasets/{dataset.id}/subimage', data=test_data)
     assert resp.status_code == 201
 
 
@@ -89,8 +86,8 @@ def test_subimage(api_client, dataset_factory):
 
 @pytest.mark.django_db
 def test_list_jobs(api_client, job_factory):
-    jobs = [job_factory() for i in range(3)]
-    jobs.sort(key=lambda d: d.id)
+    jobs = [job_factory() for i in range(10)]
+    jobs.sort(key=lambda j: j.id)
     expected_results = [models.JobDetailSerializer(job).data for job in jobs]
     resp = api_client().get('/api/v1/jobs')
     assert resp.status_code == 200
@@ -104,7 +101,8 @@ def test_list_jobs(api_client, job_factory):
 
 @pytest.mark.django_db
 def test_list_jobs_in_investigation(api_client, job_factory, investigation):
-    jobs = [job_factory(investigation=investigation) for i in range(2)]
+    jobs = [job_factory(investigation=investigation) for i in range(10)]
+    jobs.sort(key=lambda j: j.id)
     [job_factory() for i in range(3)]  # make some unrelated jobs that should not be returned
     expected_results = [models.JobDetailSerializer(job).data for job in jobs]
     resp = api_client().get(f'/api/v1/investigations/{investigation.id}/jobs')


### PR DESCRIPTION
Resolves #39 
I found that test failures were coming from instances like this, where two investigations had the same name and were therefore in a different sort order between the api and the expected test results:
![image](https://user-images.githubusercontent.com/44912689/160166782-224e260c-a27e-4861-b063-8ff58a114dba.png)
