### PR TITLE
Add menu to edit visible channels and colors

### DIFF
--- a/atlascope/core/rest/endpoints/tile_endpoints.py
+++ b/atlascope/core/rest/endpoints/tile_endpoints.py
@@ -1,4 +1,5 @@
 import io
+from itertools import cycle
 
 import PIL
 from django.urls import path
@@ -50,17 +51,7 @@ class TileView(GenericAPIView, mixins.RetrieveModelMixin):
     model = Dataset
     renderer_classes = [LargeImageRenderer]
 
-    default_colors = [
-        '#a61e1c',
-        '#cf641d',
-        '#cfba1d',
-        '#58cf1d',
-        '#1dcfab',
-        '#1d88cf',
-        '#201dcf',
-        '#a81dcf',
-        '#cf1dae',
-    ]
+    default_colors = ['#ffffff']
 
     @swagger_auto_schema(
         responses={200: 'Image file', 404: 'Image tile not found'},
@@ -118,7 +109,7 @@ class TileView(GenericAPIView, mixins.RetrieveModelMixin):
             else:
                 colors = self.default_colors
             composite = None
-            for channel, color in list(zip(channels, colors)):
+            for channel, color in list(zip(channels, cycle(colors))):
                 tile = tile_source.getTile(
                     x,
                     y,

--- a/web/src/components/InvestigationDetailFrameMenu.vue
+++ b/web/src/components/InvestigationDetailFrameMenu.vue
@@ -1,0 +1,111 @@
+<template>
+  <v-menu
+    v-model="showFrames"
+    :close-on-content-click="false"
+    offset-y
+    max-height="500px"
+  >
+    <template
+      v-slot:activator="{ on, attrs }"
+    >
+      <v-btn
+        color="blue"
+        dark
+        v-bind="attrs"
+        v-on="on"
+      >
+        Frames
+      </v-btn>
+    </template>
+    <v-card>
+      <v-card-text>
+        <v-list>
+          <v-list-item
+            v-for="frame in frameInfo"
+            :key="frame.frame"
+            :value="frame"
+          >
+            <v-list-item-action>
+              <v-switch
+                v-model="frame.displayed"
+              />
+            </v-list-item-action>
+            <v-list-item>
+              <div class="frame-row ma-0 pa-0">
+                <v-text-field
+                  v-model="frame.color"
+                  :hint="frame.name"
+                  persistent-hint
+                  maxlength="6"
+                />
+              </div>
+            </v-list-item>
+          </v-list-item>
+        </v-list>
+      </v-card-text>
+      <v-card-actions>
+        <v-btn
+          color="primary"
+          text
+          @click="updateFrameInfo"
+        >
+          Save
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-menu>
+</template>
+
+<style scoped>
+  .frame-row {
+    display: inline;
+  }
+</style>
+
+<script lang="ts">
+import {
+  ref, defineComponent, onMounted, computed, watch, Ref,
+} from '@vue/composition-api';
+import store from '../store';
+
+export default defineComponent({
+  name: 'InvestigationDetailFrameMenu',
+
+  setup() {
+    const frameInfo: Ref<any[]> = ref([]);
+    const showFrames: Ref<boolean> = ref(false);
+    const tileMetadata = computed(() => store.state.activeDatasetMetadata);
+
+    function updateFrameInfo() {
+      showFrames.value = false;
+      store.dispatch.updateFrames(frameInfo.value);
+    }
+
+    function resetFrameInfo() {
+      /* eslint-disable */
+      frameInfo.value = [];
+      const additionalMetadata: any = tileMetadata.value?.additional_metadata;
+      if (additionalMetadata.frames) {
+        frameInfo.value = additionalMetadata.frames.map((frame: any) => ({
+          name: frame.Name || 'no name',
+          frame: frame.Frame,
+          displayed: true,
+          color: '000000',
+        }));
+      }
+      store.dispatch.updateFrames(frameInfo.value);
+      /* eslint-enable */
+    }
+
+    watch(tileMetadata, () => {
+      resetFrameInfo();
+    }, { deep: true });
+
+    return {
+      updateFrameInfo,
+      frameInfo,
+      showFrames,
+    };
+  },
+});
+</script>

--- a/web/src/components/InvestigationDetailFrameMenu.vue
+++ b/web/src/components/InvestigationDetailFrameMenu.vue
@@ -74,7 +74,7 @@ export default defineComponent({
   setup() {
     const frameInfo: Ref<any[]> = ref([]);
     const showFrames: Ref<boolean> = ref(false);
-    const tileMetadata = computed(() => store.state.activeDatasetMetadata);
+    const activeDataset = computed(() => store.state.activeDataset);
 
     function updateFrameInfo() {
       showFrames.value = false;
@@ -84,22 +84,31 @@ export default defineComponent({
     function resetFrameInfo() {
       /* eslint-disable */
       frameInfo.value = [];
-      const additionalMetadata: any = tileMetadata.value?.additional_metadata;
-      if (additionalMetadata.frames) {
+      // const additionalMetadata: any = tileMetadata.value?.additional_metadata;
+      if (!activeDataset.value || !activeDataset.value.id) {
+        store.dispatch.updateFrames(frameInfo.value);
+        return;
+      }
+      const additionalMetadata: any = store.state.datasetTileMetadata[activeDataset.value.id].additional_metadata;
+      if ( additionalMetadata && additionalMetadata.frames) {
         frameInfo.value = additionalMetadata.frames.map((frame: any) => ({
           name: frame.Name || 'no name',
           frame: frame.Frame,
           displayed: true,
-          color: '000000',
+          color: 'ffffff',
         }));
       }
       store.dispatch.updateFrames(frameInfo.value);
       /* eslint-enable */
     }
 
-    watch(tileMetadata, () => {
+    watch(activeDataset, () => {
       resetFrameInfo();
-    }, { deep: true });
+    });
+
+    onMounted(() => {
+      resetFrameInfo();
+    });
 
     return {
       updateFrameInfo,

--- a/web/src/generatedTypes/AtlascopeTypes.ts
+++ b/web/src/generatedTypes/AtlascopeTypes.ts
@@ -71,6 +71,33 @@ export interface DatasetCreate {
   import_arguments: object;
 }
 
+export interface DatasetEmbedding {
+  /**
+   * Id
+   * @format uuid
+   */
+  id?: string;
+  child_bounding_box?: number[];
+
+  /**
+   * Investigation
+   * @format uuid
+   */
+  investigation: string;
+
+  /**
+   * Parent
+   * @format uuid
+   */
+  parent: string;
+
+  /**
+   * Child
+   * @format uuid
+   */
+  child: string;
+}
+
 export interface DatasetSubImage {
   /** X0 */
   x0: number;
@@ -116,11 +143,9 @@ export interface TileMetadata {
 
   /**
    * Additional metadata
-   * Any additional metadata from the tile source.
+   * Any additional metadata on the tile source.
    */
-  additional_metadata: {
-    frames: Array<Record<string, string>>;
-  }
+  additional_metadata?: object;
 }
 
 export interface Investigation {
@@ -346,6 +371,20 @@ export namespace Datasets {
   /**
    * No description
    * @tags datasets
+   * @name DatasetsEmbeddings
+   * @request GET:/datasets/{id}/embeddings
+   * @response `200` `(DatasetEmbedding)[]`
+   */
+  export namespace DatasetsEmbeddings {
+    export type RequestParams = { id: string };
+    export type RequestQuery = {};
+    export type RequestBody = never;
+    export type RequestHeaders = {};
+    export type ResponseBody = DatasetEmbedding[];
+  }
+  /**
+   * No description
+   * @tags datasets
    * @name DatasetsSubimage
    * @request POST:/datasets/{id}/subimage
    * @response `201` `DatasetSubImage`
@@ -453,11 +492,11 @@ export namespace Investigations {
   /**
    * No description
    * @tags investigations
-   * @name InvestigationsPins
+   * @name InvestigationsPinsRead
    * @request GET:/investigations/{id}/pins
    * @response `200` `(Pin)[]`
    */
-  export namespace InvestigationsPins {
+  export namespace InvestigationsPinsRead {
     export type RequestParams = { id: string };
     export type RequestQuery = {};
     export type RequestBody = never;

--- a/web/src/generatedTypes/AtlascopeTypes.ts
+++ b/web/src/generatedTypes/AtlascopeTypes.ts
@@ -71,33 +71,6 @@ export interface DatasetCreate {
   import_arguments: object;
 }
 
-export interface DatasetEmbedding {
-  /**
-   * Id
-   * @format uuid
-   */
-  id?: string;
-  child_bounding_box?: number[];
-
-  /**
-   * Investigation
-   * @format uuid
-   */
-  investigation: string;
-
-  /**
-   * Parent
-   * @format uuid
-   */
-  parent: string;
-
-  /**
-   * Child
-   * @format uuid
-   */
-  child: string;
-}
-
 export interface DatasetSubImage {
   /** X0 */
   x0: number;
@@ -371,20 +344,6 @@ export namespace Datasets {
   /**
    * No description
    * @tags datasets
-   * @name DatasetsEmbeddings
-   * @request GET:/datasets/{id}/embeddings
-   * @response `200` `(DatasetEmbedding)[]`
-   */
-  export namespace DatasetsEmbeddings {
-    export type RequestParams = { id: string };
-    export type RequestQuery = {};
-    export type RequestBody = never;
-    export type RequestHeaders = {};
-    export type ResponseBody = DatasetEmbedding[];
-  }
-  /**
-   * No description
-   * @tags datasets
    * @name DatasetsSubimage
    * @request POST:/datasets/{id}/subimage
    * @response `201` `DatasetSubImage`
@@ -464,11 +423,11 @@ export namespace Investigations {
   /**
    * No description
    * @tags investigations
-   * @name InvestigationsEmbeddings
+   * @name InvestigationsEmbeddingsRead
    * @request GET:/investigations/{id}/embeddings
    * @response `200` `(DatasetEmbedding)[]`
    */
-  export namespace InvestigationsEmbeddings {
+  export namespace InvestigationsEmbeddingsRead {
     export type RequestParams = { id: string };
     export type RequestQuery = {};
     export type RequestBody = never;

--- a/web/src/store/index.ts
+++ b/web/src/store/index.ts
@@ -19,6 +19,7 @@ export interface State {
     selectedPins: Pin[];
     datasetEmbeddings: DatasetEmbedding[];
     datasetTileMetadata: { [key: string]: TileMetadata };
+    activeDatasetMetadata: TileMetadata | null;
 }
 
 interface TileMetadataForDataset {
@@ -43,6 +44,7 @@ const {
     selectedPins: [],
     datasetEmbeddings: [],
     datasetTileMetadata: {},
+    activeDatasetMetadata: null,
   } as State,
   mutations: {
     setInvestigations(state, investigations: Investigation[]) {
@@ -71,6 +73,9 @@ const {
     },
     setTileMetadataForDataset(state, obj: TileMetadataForDataset) {
       state.datasetTileMetadata[obj.datasetId] = obj.tileMetadata;
+    },
+    setActiveDatasetMetadata(state, metadata: TileMetadata | null) {
+      state.activeDatasetMetadata = metadata;
     },
   },
   getters: {
@@ -168,6 +173,17 @@ const {
     updateSelectedPins(context, pins: Pin[]) {
       const { commit } = rootActionContext(context);
       commit.setSelectedPins(pins);
+    },
+    async fetchDatasetMetadata(context, datasetId: string): Promise<TileMetadata | null> {
+      const { commit } = rootActionContext(context);
+      if (store.state.axiosInstance) {
+        const url = `/datasets/${datasetId}/tiles/metadata`;
+        const metadata = (await store.state.axiosInstance.get(url)).data;
+        commit.setActiveDatasetMetadata(metadata);
+        return metadata;
+      }
+      commit.setActiveDatasetMetadata(null);
+      return null;
     },
     storeAxiosInstance(context, axiosInstance) {
       const { commit } = rootActionContext(context);

--- a/web/src/store/index.ts
+++ b/web/src/store/index.ts
@@ -9,6 +9,13 @@ import {
 
 Vue.use(Vuex);
 
+interface TiffFrame {
+  name: string;
+  frame: number;
+  displayed: boolean;
+  color: string;
+}
+
 export interface State {
     investigations: Investigation[];
     axiosInstance: AxiosInstance | null;
@@ -20,6 +27,7 @@ export interface State {
     datasetEmbeddings: DatasetEmbedding[];
     datasetTileMetadata: { [key: string]: TileMetadata };
     activeDatasetMetadata: TileMetadata | null;
+    activeDatasetFrames: TiffFrame[];
 }
 
 interface TileMetadataForDataset {
@@ -45,6 +53,7 @@ const {
     datasetEmbeddings: [],
     datasetTileMetadata: {},
     activeDatasetMetadata: null,
+    activeDatasetFrames: [],
   } as State,
   mutations: {
     setInvestigations(state, investigations: Investigation[]) {
@@ -76,6 +85,9 @@ const {
     },
     setActiveDatasetMetadata(state, metadata: TileMetadata | null) {
       state.activeDatasetMetadata = metadata;
+    },
+    setActiveDatasetFrames(state, frames: TiffFrame[]) {
+      state.activeDatasetFrames = frames;
     },
   },
   getters: {
@@ -173,6 +185,10 @@ const {
     updateSelectedPins(context, pins: Pin[]) {
       const { commit } = rootActionContext(context);
       commit.setSelectedPins(pins);
+    },
+    updateFrames(context, frames: TiffFrame[]) {
+      const { commit } = rootActionContext(context);
+      commit.setActiveDatasetFrames(frames);
     },
     async fetchDatasetMetadata(context, datasetId: string): Promise<TileMetadata | null> {
       const { commit } = rootActionContext(context);

--- a/web/src/store/index.ts
+++ b/web/src/store/index.ts
@@ -26,7 +26,6 @@ export interface State {
     selectedPins: Pin[];
     datasetEmbeddings: DatasetEmbedding[];
     datasetTileMetadata: { [key: string]: TileMetadata };
-    activeDatasetMetadata: TileMetadata | null;
     activeDatasetFrames: TiffFrame[];
 }
 
@@ -52,7 +51,6 @@ const {
     selectedPins: [],
     datasetEmbeddings: [],
     datasetTileMetadata: {},
-    activeDatasetMetadata: null,
     activeDatasetFrames: [],
   } as State,
   mutations: {
@@ -82,9 +80,6 @@ const {
     },
     setTileMetadataForDataset(state, obj: TileMetadataForDataset) {
       state.datasetTileMetadata[obj.datasetId] = obj.tileMetadata;
-    },
-    setActiveDatasetMetadata(state, metadata: TileMetadata | null) {
-      state.activeDatasetMetadata = metadata;
     },
     setActiveDatasetFrames(state, frames: TiffFrame[]) {
       state.activeDatasetFrames = frames;
@@ -189,17 +184,6 @@ const {
     updateFrames(context, frames: TiffFrame[]) {
       const { commit } = rootActionContext(context);
       commit.setActiveDatasetFrames(frames);
-    },
-    async fetchDatasetMetadata(context, datasetId: string): Promise<TileMetadata | null> {
-      const { commit } = rootActionContext(context);
-      if (store.state.axiosInstance) {
-        const url = `/datasets/${datasetId}/tiles/metadata`;
-        const metadata = (await store.state.axiosInstance.get(url)).data;
-        commit.setActiveDatasetMetadata(metadata);
-        return metadata;
-      }
-      commit.setActiveDatasetMetadata(null);
-      return null;
     },
     storeAxiosInstance(context, axiosInstance) {
       const { commit } = rootActionContext(context);

--- a/web/src/views/InvestigationDetail.vue
+++ b/web/src/views/InvestigationDetail.vue
@@ -151,7 +151,6 @@ export default defineComponent({
 
     const selectedDataset: Ref<Dataset | null> = ref(null);
     const activeDataset = computed(() => store.state.activeDataset);
-    const activeDatasetMetadata = computed(() => store.state.activeDatasetMetadata);
     const tilesourceDatasets = computed(() => store.getters.tilesourceDatasets);
     /* eslint-disable */
     let featureLayer: any;
@@ -299,7 +298,6 @@ export default defineComponent({
       map,
       tilesourceDatasets,
       activeDataset,
-      activeDatasetMetadata,
       selectedDataset,
       activeDatasetChanged,
       selectedPins,


### PR DESCRIPTION
This is a basic implementation of a component that allows changing which tiff channels are visible, and what color each channel should be. Currently it works with the `InvestigationDetail` view to allow customizing channels for the current active dataset. 

In that view, click the new `FRAMES` button and explore toggling various  channels and changing their color.