### PR TITLE
Convert images upon ingest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,8 @@ jobs:
             `# GEOS library development files (GeoDjango)` \
             libgeos-dev \
             `# TIFF reading` \
-            libtiff-dev
+            libtiff-dev \
+            libvips \
         shell: bash
       - uses: actions/checkout@v2
       - name: Install tox

--- a/atlascope/core/importers/base_importer.py
+++ b/atlascope/core/importers/base_importer.py
@@ -1,9 +1,13 @@
+import imghdr
 from inspect import Parameter, signature
 from io import BytesIO
 from pathlib import Path
 import tempfile
-import large_image_converter
 
+from large_image.exceptions import TileSourceError
+import large_image_converter
+from large_image_source_ometiff import OMETiffFileTileSource
+from large_image_source_tiff import TiffFileTileSource
 from rest_framework.exceptions import APIException
 from rest_framework.serializers import ValidationError
 
@@ -59,6 +63,13 @@ class AtlascopeImporter:
             dest = Path(tmpdirname, 'gdal_conversion')
             with open(dest, 'wb') as fd:
                 fd.write(self.content.getvalue())
-            converted = large_image_converter.convert(str(dest))
-            with open(converted, 'rb') as result:
-                self.content = BytesIO(result.read())
+            if imghdr.what(dest) == 'tiff':
+                try:
+                    tile_source = OMETiffFileTileSource(dest)
+                except TileSourceError:
+                    tile_source = TiffFileTileSource(dest)
+                channel_info = tile_source.getMetadata()['channels']
+                self.metadata['channels'] = channel_info
+                converted = large_image_converter.convert(str(dest))
+                with open(converted, 'rb') as result:
+                    self.content = BytesIO(result.read())

--- a/atlascope/core/management/commands/populate.py
+++ b/atlascope/core/management/commands/populate.py
@@ -1,9 +1,7 @@
 import json
+import logging
 import os
 from pathlib import Path
-import tempfile
-import large_image_converter
-import logging
 
 from django.contrib.gis.geos import Point
 from django.contrib.gis.geos.polygon import Polygon
@@ -65,12 +63,7 @@ def populate_datasets(specs):
         # If there's content to save, save it.
         if content:
             print("    uploading data...", end="", flush=True)
-            with tempfile.TemporaryDirectory() as tmpdirname:
-                dest = Path(tmpdirname, 'gdal_conversion')
-                with open(dest, 'wb') as fd:
-                    fd.write(open(POPULATE_DIR / "inputs" / content, "rb").read())
-                converted = large_image_converter.convert(str(dest))
-                dataset.content.save(content, open(converted, 'rb'))
+            dataset.perform_import(content=open(POPULATE_DIR / "inputs" / content, "rb").read())
             print("done")
 
         # If there's an importer to run, run it.

--- a/atlascope/core/models/dataset.py
+++ b/atlascope/core/models/dataset.py
@@ -40,6 +40,7 @@ class Dataset(TimeStampedModel, models.Model):
         self.metadata = importer_obj.metadata
         if not self.name:
             self.name = importer_obj.dataset_name or f'{importer} {self.id}'
+        self.save()
 
     def subimage(self, x0: int, x1: int, y0: int, y1: int) -> 'Dataset':
         metadata = {

--- a/dev/django.Dockerfile
+++ b/dev/django.Dockerfile
@@ -17,6 +17,8 @@ RUN apt-get update \
         libgeos-dev \
         # TIFF reading
         libtiff-dev \
+        # Large Image Converter dependency
+        libvips \
         # Nginx to proxy localhost
         nginx \
  && pip install --upgrade pip \

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         'fsspec',
         'importlib_metadata>=3.6',
         'large-image[gdal,ometiff]',
+        'large-image-converter',
         # Production-only
         'django-composed-configuration[prod]>=0.18',
         'django-s3-file-field[boto3]',


### PR DESCRIPTION
As a rival solution to #118, this branch explores the viability of converting large images upon ingest to a format supported by the `GDALFileTileSource` class (so that we can utilize `vsicurl` and avoid downloading the whole file)

I was able to use large-image-converter successfully, but when I do so, we lose some information from the metadata endpoint. Without conversion and using `OMETiffFileTileSource`, we get metadata like this, which includes `channelMap`:
```
{
  "levels": 4,
  "size_x": 5001,
  "size_y": 5001,
  "tile_size": 1024,
  "additional_metadata": {
    "levels": 4,
    "sizeX": 5001,
    "sizeY": 5001,
    "tileWidth": 1024,
    "tileHeight": 1024,
    "magnification": 19.912385503783355,
    "mm_x": 0.0005022,
    "mm_y": 0.0005022,
    "frames": [
      {
        "LightPath": {},
        "ID": "Channel:0:0",
        "Name": "NUCLEI",
        "SamplesPerPixel": "1",
        "IndexC": 0,
        "Frame": 0,
        "Index": 0,
        "Channel": "NUCLEI"
      },
      ...
    ],
    "IndexRange": {
      "IndexC": 12
    },
    "IndexStride": {
      "IndexC": 1
    },
    "channels": [
      "NUCLEI",
      "CD4",
      "CD3",
      "PD1",
      "KI67",
      "CD8",
      "EOMES",
      "GRZB",
      "IDO",
      "TBET",
      "CD68",
      "CD45"
    ],
    "channelmap": {
      "NUCLEI": 0,
      "CD4": 1,
      "CD3": 2,
      "PD1": 3,
      "KI67": 4,
      "CD8": 5,
      "EOMES": 6,
      "GRZB": 7,
      "IDO": 8,
      "TBET": 9,
      "CD68": 10,
      "CD45": 11
    }
  }
}
```


When I do convert and use the same tile source code, we get metadata like this:
```
{
  "levels": 6,
  "size_x": 5001,
  "size_y": 5001,
  "tile_size": 256,
  "additional_metadata": {
    "levels": 6,
    "sizeX": 5001,
    "sizeY": 5001,
    "tileWidth": 256,
    "tileHeight": 256,
    "magnification": null,
    "mm_x": null,
    "mm_y": null,
    "frames": [
      {
        "Frame": 0,
        "Index": 0
      },
      {
        "Frame": 1,
        "Index": 0
      },
      ...
      {
        "Frame": 11,
        "Index": 0
      }
    ]
  }
}
```

Unless there are configurable options to the `convert` function that will allow us to maintain this important metadata, this is the less viable contender.