### PR TITLE
Add yarn to docker-compose services

### DIFF
--- a/dev/yarn.Dockerfile
+++ b/dev/yarn.Dockerfile
@@ -1,9 +1,0 @@
-FROM yarnpkg/node-yarn:latest
-
-RUN mkdir /web
-WORKDIR /web
-COPY ./web /web
-RUN npm cache clean -f
-RUN npm install n -g -q
-RUN n stable -q
-RUN npm install -q

--- a/dev/yarn.Dockerfile
+++ b/dev/yarn.Dockerfile
@@ -1,0 +1,9 @@
+FROM yarnpkg/node-yarn:latest
+
+RUN mkdir /web
+WORKDIR /web
+COPY ./web /web
+RUN npm cache clean -f
+RUN npm install n -g -q
+RUN n stable -q
+RUN npm install -q

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -38,6 +38,14 @@ services:
       - postgres
       - rabbitmq
 
+  yarn:
+    build:
+      context: .
+      dockerfile: ./dev/yarn.Dockerfile
+    volumes:
+      - ./web:/web
+    command: yarn serve
+
   demotiles:
     build:
       context: ./dev/demotiles

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -39,7 +39,7 @@ services:
       - rabbitmq
 
   yarn:
-    image: node:latest
+    image: node:18
     working_dir: /web
     volumes:
       - ./web:/web

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -39,14 +39,15 @@ services:
       - rabbitmq
 
   yarn:
-    build:
-      context: .
-      dockerfile: ./dev/yarn.Dockerfile
+    image: node:latest
+    working_dir: /web
     volumes:
       - ./web:/web
     command: yarn serve
     ports:
       - 8080:8080
+    environment:
+      - NODE_OPTIONS=--openssl-legacy-provider
 
   demotiles:
     build:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -45,6 +45,8 @@ services:
     volumes:
       - ./web:/web
     command: yarn serve
+    ports:
+      - 8080:8080
 
   demotiles:
     build:

--- a/web/package.json
+++ b/web/package.json
@@ -57,7 +57,7 @@
       "ecmaVersion": 2020
     },
     "rules": {
-      "no-console": "off"
+      "no-console": "warn"
     },
     "overrides": [
       {

--- a/web/package.json
+++ b/web/package.json
@@ -56,7 +56,9 @@
     "parserOptions": {
       "ecmaVersion": 2020
     },
-    "rules": {},
+    "rules": {
+      "no-console": "off"
+    },
     "overrides": [
       {
         "files": [

--- a/web/vue.config.js
+++ b/web/vue.config.js
@@ -6,4 +6,9 @@ module.exports = {
     //  it has no effect.
     'vuetify',
   ],
+
+  // disable all the progress printout from webpack
+  devServer: {
+		progress: false
+	},
 };

--- a/web/vue.config.js
+++ b/web/vue.config.js
@@ -9,6 +9,6 @@ module.exports = {
 
   // disable all the progress printout from webpack
   devServer: {
-		progress: false
-	},
+    progress: false,
+  },
 };


### PR DESCRIPTION
It may be beneficial to roll yarn into our docker services so that we don't need separate terminals running `docker-compose up` and `yarn serve`. @naglepuff @mcovalt What do you think?