### PR TITLE
Use `django-large-image` styling for bands

### DIFF
--- a/atlascope/core/rest/endpoints/tile_endpoints.py
+++ b/atlascope/core/rest/endpoints/tile_endpoints.py
@@ -36,34 +36,6 @@ class DatasetTileSourceView(GenericViewSet, LargeImageDetailMixin):
             tile_source = TiffFileTileSource(path, *args, **kwargs)
         return tile_source
 
-    def get_style(self, request: Request) -> dict:
-        """Override django-large-image style parsing for cutom frame stuff.
-
-        This builds a style dictionary for large-image following:
-
-            https://girder.github.io/large_image/tilesource_options.html#style
-
-        """
-        channels = request.query_params.get('channels')
-        if channels:
-            channels = channels.split(',')
-        else:
-            tile_source = self.open_tile_source(self.get_path())  # TODO: better handle upstream
-            channels = range(len(tile_source.getMetadata()['frames']))
-        colors = request.query_params.get('colors')
-        if colors:
-            colors = [f'#{color}' for color in colors.split(',')]
-        else:
-            colors = self.default_colors
-        style = {'bands': []}
-        for channel, color in list(zip(channels, cycle(colors))):
-            style['bands'].append(
-                {
-                    'frame': channel,
-                    'palette': ['#000', color],
-                }
-            )
-        return style
 
 
 router = DefaultRouter(trailing_slash=False)

--- a/atlascope/core/rest/endpoints/tile_endpoints.py
+++ b/atlascope/core/rest/endpoints/tile_endpoints.py
@@ -1,12 +1,9 @@
-from itertools import cycle
-
 from django_large_image.rest.viewsets import LargeImageDetailMixin
 from large_image.exceptions import TileSourceError
 from large_image.tilesource import FileTileSource
 from large_image_source_ometiff import OMETiffFileTileSource
 from large_image_source_tiff import TiffFileTileSource
 from rest_framework.exceptions import ValidationError
-from rest_framework.request import Request
 from rest_framework.routers import DefaultRouter
 from rest_framework.viewsets import GenericViewSet
 
@@ -35,7 +32,6 @@ class DatasetTileSourceView(GenericViewSet, LargeImageDetailMixin):
         except TileSourceError:
             tile_source = TiffFileTileSource(path, *args, **kwargs)
         return tile_source
-
 
 
 router = DefaultRouter(trailing_slash=False)

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         'importlib_metadata>=3.6',
         'jsonschema',
         'large-image[gdal,ometiff]>=1.13.0',
-        'django-large-image>=0.4.1',
+        'django-large-image>=0.4.3',
         # Production-only
         'django-composed-configuration[prod]>=0.18',
         'gunicorn',

--- a/web/src/store/index.ts
+++ b/web/src/store/index.ts
@@ -9,7 +9,7 @@ import {
 
 Vue.use(Vuex);
 
-interface TiffFrame {
+export interface TiffFrame {
   name: string;
   frame: number;
   displayed: boolean;

--- a/web/src/views/InvestigationDetail.vue
+++ b/web/src/views/InvestigationDetail.vue
@@ -224,7 +224,7 @@ export default defineComponent({
     function getSelectedFrameStyle(): BandSpec[] {
       return frames.value.filter((frame: TiffFrame) => frame.displayed).map((frame: TiffFrame) => ({
         frame: frame.frame,
-        palette: ['#000', `#${frame.color}`],
+        palette: `#${frame.color}`,
       }));
     }
 

--- a/web/src/views/InvestigationDetail.vue
+++ b/web/src/views/InvestigationDetail.vue
@@ -153,7 +153,7 @@ interface StackFrame {
 
 interface BandSpec {
   frame: number;
-  palette: string[];
+  palette: string;
 }
 
 interface TileLayerStyleDict {

--- a/web/src/views/InvestigationDetail.vue
+++ b/web/src/views/InvestigationDetail.vue
@@ -125,7 +125,7 @@ import {
 } from '@vue/composition-api';
 import useGeoJS from '../utilities/useGeoJS';
 import { postGisToPoint } from '../utilities/utiltyFunctions';
-import store from '../store';
+import store, { TiffFrame } from '../store';
 import DatasetSubimageSelector from '../components/DatasetSubimageSelector.vue';
 import InvestigationSidebar from '../components/InvestigationSidebar.vue';
 import InvestigationDetailFrameMenu from '../components/InvestigationDetailFrameMenu.vue';
@@ -149,6 +149,15 @@ interface StackFrame {
     };
   };
   treeDepth: number;
+}
+
+interface BandSpec {
+  frame: number;
+  palette: string[];
+}
+
+interface TileLayerStyleDict {
+  bands: BandSpec[];
 }
 
 export default defineComponent({
@@ -197,7 +206,7 @@ export default defineComponent({
     const pinNotes: Ref<any[]> = ref([]);
     /* eslint-enable */
     const rootDatasetLayer: Ref<any> = ref(null);
-    const frames = computed(() => store.state.rootDatasetFrames);
+    const frames: Ref<TiffFrame[]> = computed(() => store.state.rootDatasetFrames);
     /* eslint-enable */
 
     function rootDatasetChanged(newRootDataset: Dataset) {
@@ -212,20 +221,19 @@ export default defineComponent({
       ));
     }
 
+    function getSelectedFrameStyle(): BandSpec[] {
+      return frames.value.filter((frame: TiffFrame) => frame.displayed).map((frame: TiffFrame) => ({
+        frame: frame.frame,
+        palette: ['#000', `#${frame.color}`],
+      }));
+    }
+
     function buildUrlQueryArgs() {
-      const channels: number[] = [];
-      const colors: string[] = [];
-      /* eslint-disable */
-      const selectedFrames = frames.value.filter((frame: any) => frame.displayed);
-      if (selectedFrames.length === 0) {
-        return '';
-      }
-      selectedFrames.forEach((frame) => {
-        channels.push(frame.frame);
-        colors.push(frame.color);
-      });
-      /* eslint-enable */
-      return `?channels=${channels.join(',')}&colors=${colors.join(',')}`;
+      const style: TileLayerStyleDict = {
+        bands: getSelectedFrameStyle(),
+      };
+      const encodedStyle = encodeURIComponent(JSON.stringify(style));
+      return `?style=${encodedStyle}`;
     }
 
     function tearDownMap() {


### PR DESCRIPTION
This change makes our front end conform to the best practices laid out in `django-large-image` [documentation](https://github.com/girder/django-large-image#-styling). Targeting #135 as the base since this change doesn't make sense without `django-large-image`.

Closes #138 