### PR TITLE
Move pan and zoom GeoJS events to useGeoJS

### DIFF
--- a/web/src/views/InvestigationDetail.vue
+++ b/web/src/views/InvestigationDetail.vue
@@ -177,6 +177,9 @@ export default defineComponent({
       createLayer,
       geoEvents,
       geoAnnotations,
+      zoomLevel,
+      xCoord,
+      yCoord,
     } = useGeoJS(map);
     const loaded = ref(false);
     const sidebarCollapsed = ref(true);
@@ -259,6 +262,10 @@ export default defineComponent({
       });
     }
 
+    watch([zoomLevel, xCoord, yCoord], () => {
+      movePinNoteCards();
+    });
+
     function drawMap(dataset: Dataset | null) {
       tearDownMap();
       if (!dataset || !dataset.id) {
@@ -296,7 +303,7 @@ export default defineComponent({
         url: `${apiRoot}/datasets/${rootDatasetID}/tiles/{z}/{x}/{y}.png`,
         crossDomain: 'use-credentials',
       };
-      const geojsMap = createMap(mapParams);
+      createMap(mapParams);
       rootDatasetLayer.value = createLayer('osm', rootLayerParams);
 
       const visited: Set<RootDatasetEmbedding | DatasetEmbedding> = new Set();
@@ -391,8 +398,6 @@ export default defineComponent({
           /* eslint-enable */
         }
       }
-      geojsMap.geoOn(geoEvents.pan, movePinNoteCards);
-      geojsMap.geoOn(geoEvents.zoom, movePinNoteCards);
       clampBoundsX(false);
     }
 


### PR DESCRIPTION
@mcovalt can you take a look at my attempt to move some geojs stuff back to `useGeoJS`? So far I've addressed zoom/pan but I'm open to expanding the scope of this PR if there's more stuff that we should address at this time.

I'll mention #128 here but this PR does not yet fully address the issue (there's still the matter of individual layers).