### PR TITLE
Manually trigger change to tiff frames

### DIFF
--- a/web/src/components/InvestigationDetailFrameMenu.vue
+++ b/web/src/components/InvestigationDetailFrameMenu.vue
@@ -22,7 +22,17 @@
       </v-tooltip>
     </template>
     <v-card>
-      <v-card-text>
+      <v-card-actions>
+        <v-btn
+          color="primary"
+          text
+          :disabled="!validColors"
+          @click="updateFrameInfo"
+        >
+          Update
+        </v-btn>
+      </v-card-actions>
+      <v-card-text class="ma-0 pa-0">
         <v-list>
           <v-list-item
             v-for="frame in frameInfo"
@@ -39,6 +49,7 @@
                 <v-text-field
                   v-model="frame.color"
                   :hint="frame.name"
+                  :rules="[isColorStringRule]"
                   persistent-hint
                   maxlength="6"
                 />
@@ -47,15 +58,6 @@
           </v-list-item>
         </v-list>
       </v-card-text>
-      <v-card-actions>
-        <v-btn
-          color="primary"
-          text
-          @click="updateFrameInfo"
-        >
-          Save
-        </v-btn>
-      </v-card-actions>
     </v-card>
   </v-menu>
 </template>
@@ -70,25 +72,28 @@
 import {
   ref, defineComponent, onMounted, computed, watch, Ref,
 } from '@vue/composition-api';
-import store from '../store';
+import store, { TiffFrame } from '../store';
+import { isColorStringRule } from '../utilities/utiltyFunctions';
 
 export default defineComponent({
   name: 'InvestigationDetailFrameMenu',
 
   setup() {
-    const frameInfo: Ref<any[]> = ref([]);
+    const frameInfo: Ref<TiffFrame[]> = ref([]);
     const showFrames: Ref<boolean> = ref(false);
     const rootDataset = computed(() => store.state.rootDataset);
+    const validColors = computed(
+      () => frameInfo.value.every((frame: TiffFrame) => isColorStringRule(frame.color)),
+    );
 
     function updateFrameInfo() {
       showFrames.value = false;
-      store.dispatch.updateFrames(frameInfo.value);
+      store.dispatch.updateFrames(JSON.parse(JSON.stringify(frameInfo.value)));
     }
 
     function resetFrameInfo() {
       /* eslint-disable */
       frameInfo.value = [];
-      // const additionalMetadata: any = tileMetadata.value?.additional_metadata;
       if (!rootDataset.value || !rootDataset.value.id) {
         store.dispatch.updateFrames(frameInfo.value);
         return;
@@ -102,7 +107,7 @@ export default defineComponent({
           color: 'ffffff',
         }));
       }
-      store.dispatch.updateFrames(frameInfo.value);
+      store.dispatch.updateFrames(JSON.parse(JSON.stringify(frameInfo.value)));
       /* eslint-enable */
     }
 
@@ -118,6 +123,8 @@ export default defineComponent({
       updateFrameInfo,
       frameInfo,
       showFrames,
+      isColorStringRule,
+      validColors,
     };
   },
 });

--- a/web/src/components/InvestigationDetailFrameMenu.vue
+++ b/web/src/components/InvestigationDetailFrameMenu.vue
@@ -83,7 +83,7 @@ export default defineComponent({
     const showFrames: Ref<boolean> = ref(false);
     const rootDataset = computed(() => store.state.rootDataset);
     const validColors = computed(
-      () => frameInfo.value.every((frame: TiffFrame) => isColorStringRule(frame.color)),
+      () => frameInfo.value.every((frame: TiffFrame) => isColorStringRule(frame.color) === true),
     );
 
     function updateFrameInfo() {

--- a/web/src/components/InvestigationDetailFrameMenu.vue
+++ b/web/src/components/InvestigationDetailFrameMenu.vue
@@ -6,16 +6,20 @@
     max-height="500px"
   >
     <template
-      v-slot:activator="{ on, attrs }"
+      v-slot:activator="{ on: onMenu, attrs: attrsMenu }"
     >
-      <v-btn
-        color="blue"
-        dark
-        v-bind="attrs"
-        v-on="on"
-      >
-        Frames
-      </v-btn>
+      <v-tooltip bottom>
+        <template v-slot:activator="{ on: onTooltip, attrs: attrsTooltip }">
+          <v-btn
+            icon
+            v-bind="{ ...attrsMenu, ...attrsTooltip }"
+            v-on="{ ...onMenu, ...onTooltip }"
+          >
+            <v-icon>mdi-palette</v-icon>
+          </v-btn>
+        </template>
+        <span>Edit the image style</span>
+      </v-tooltip>
     </template>
     <v-card>
       <v-card-text>

--- a/web/src/store/index.ts
+++ b/web/src/store/index.ts
@@ -9,7 +9,7 @@ import {
 
 Vue.use(Vuex);
 
-interface TiffFrame {
+export interface TiffFrame {
   name: string;
   frame: number;
   displayed: boolean;

--- a/web/src/utilities/utiltyFunctions.ts
+++ b/web/src/utilities/utiltyFunctions.ts
@@ -17,3 +17,8 @@ export function postGisToPoint(location: string): Point | undefined {
   }
   return undefined;
 }
+
+export function isColorStringRule(value: string): boolean | string {
+  const hexRegEx = /^([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/;
+  return hexRegEx.test(value) || 'Enter a valid 3- or 6-digit hex code';
+}

--- a/web/src/views/InvestigationDetail.vue
+++ b/web/src/views/InvestigationDetail.vue
@@ -12,7 +12,7 @@
         <v-select
           v-if="!loaded || tilesourceDatasets.length > 0"
           v-model="selectedDataset"
-          class="atlascope-dataset-select"
+          class="pr-6"
           :items="tilesourceDatasets"
           item-text="name"
           item-value="id"


### PR DESCRIPTION
Closes #137 

Previously, the URL for the root dataset layer was updated anytime there was a change to the `rootDatasetFrames` property in the store. This property was bound to the form in the `InvestigationDetailFrameMenu`. This meant that any change to any field on that form would trigger a URL change, often with invalid color strings.

Now, this binding has been removed. The user must click the `UPDATE` button to trigger a URL change. Additionally, valid color strings are enforced, and the button is disabled if any text input contains an invalid color string.