### PR TITLE
Download once, populate many

### DIFF
--- a/atlascope/core/management/populate/datasets.json
+++ b/atlascope/core/management/populate/datasets.json
@@ -23,7 +23,8 @@
         "description": "Vandy test dataset 3 (https://styx.neurology.emory.edu/girder/#item/60e84a1968f4fe34fc7eef79), retrieved via Vandy importer",
         "importer": {
             "importer": "VandyImporter",
-            "file_id": "60e84a1868f4fe34fc7eef72"
+            "file_id": "60e84a1868f4fe34fc7eef72",
+            "sha256sum": "4c98465bde02089067d5736126f00a034a17d17b88f00d27d046a63554811b1d"
         }
     },
     {

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,4 +1,8 @@
 version: '3'
+
+volumes:
+  pooch_cache:
+
 services:
   django:
     build:
@@ -11,6 +15,7 @@ services:
     volumes:
       - .:/opt/django-project
       - ./data:/opt/django-project/data
+      - pooch_cache:/root/.cache/pooch
     ports:
       - 8000:8000
     depends_on:

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup(
     extras_require={
         'dev': [
             'pooch',
+            'tqdm',  # for progress bar in pooch
             'django-composed-configuration[dev]>=0.18',
             'django-debug-toolbar',
             'ipython',

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
     ],
     extras_require={
         'dev': [
+            'pooch',
             'django-composed-configuration[dev]>=0.18',
             'django-debug-toolbar',
             'ipython',


### PR DESCRIPTION
Related to #152

This PR uses [pooch](https://github.com/fatiando/pooch) to download files in the [`VandyImporter`](https://github.com/atlascope/atlascope/blob/cached-dev-files/atlascope/core/importers/vandy.py). The folder containing cached downloads is persisted via our Docker Compose configuration.