### PR TITLE
Add cached downloads to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,12 @@ jobs:
         ports:
           - 5672:5672
     steps:
+      - name: Cache Pooch
+        id: cache-pooch
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pooch
+          key: ${{ runner.os }}-pooch
       - name: Install dependencies
         run: |
           # Install system libraries for Python packages:


### PR DESCRIPTION
Related to #152

This PR should alter the GitHub Actions CI to persist the the `$XDG_CACHE_HOME/pooch` folder between runs. This will prevent re-downloading large files used in testing.