### PR TITLE
Smooth out pin transition during zoom in/out

### DIFF
--- a/web/src/utilities/utiltyFunctions.ts
+++ b/web/src/utilities/utiltyFunctions.ts
@@ -17,3 +17,27 @@ export function postGisToPoint(location: string): Point | undefined {
   }
   return { x: xCoord, y: yCoord };
 }
+
+export function radiusForZoomLevel(currentZoom: number, minZoom: number): number {
+  const maxRadius = 10;
+  if (currentZoom >= minZoom) {
+    return maxRadius;
+  }
+  const diff = minZoom - currentZoom;
+  if (diff > 2) {
+    return 0;
+  }
+  return maxRadius - (5 * diff);
+}
+
+export function opacityForZoomLevel(currentZoom: number, maxZoom: number): number {
+  const maxOpacity = 0.8;
+  if (currentZoom <= maxZoom) {
+    return maxOpacity;
+  }
+  const diff = currentZoom - maxZoom;
+  if (diff > 2) {
+    return 0;
+  }
+  return maxOpacity - (0.4 * diff);
+}

--- a/web/src/utilities/utiltyFunctions.ts
+++ b/web/src/utilities/utiltyFunctions.ts
@@ -18,16 +18,24 @@ export function postGisToPoint(location: string): Point | undefined {
   return { x: xCoord, y: yCoord };
 }
 
-export function radiusForZoomLevel(currentZoom: number, minZoom: number): number {
-  const maxRadius = 10;
-  if (currentZoom >= minZoom) {
-    return maxRadius;
+export function radiusForZoomLevel(currentZoom: number, minZoom: number, maxZoom: number): number {
+  const inRangeRadius = 10;
+  let diff = 0;
+  if (currentZoom >= minZoom && currentZoom <= maxZoom) {
+    return inRangeRadius;
   }
-  const diff = minZoom - currentZoom;
+  if (currentZoom < minZoom) {
+    diff = minZoom - currentZoom;
+    if (diff > 2) {
+      return 0;
+    }
+    return inRangeRadius - (5 * diff);
+  }
+  diff = currentZoom - maxZoom;
   if (diff > 2) {
-    return 0;
+    return inRangeRadius;
   }
-  return maxRadius - (5 * diff);
+  return inRangeRadius + (8 * diff);
 }
 
 export function opacityForZoomLevel(currentZoom: number, maxZoom: number): number {

--- a/web/src/views/InvestigationDetail.vue
+++ b/web/src/views/InvestigationDetail.vue
@@ -259,9 +259,10 @@ export default defineComponent({
       if (!featureLayer || !pinFeature || !map.value) { return; }
       pinFeature.getData().forEach((pin: object) => {
         if (!pinFeature) return;
-        const { x, y } = postGisToPoint((pin as Pin).location) || { x: 0, y: 0 };
+        const pinObject = pin as Pin;
+        const { x, y } = postGisToPoint(pinObject.location) || { x: 0, y: 0 };
         const newScreenCoords = pinFeature.featureGcsToDisplay(x, y);
-        const note = pinNotes.value.find((pinNote) => pinNote.id === (pin as Pin).id);
+        const note = pinNotes.value.find((pinNote) => pinNote.id === pinObject.id);
         const {
           left, top, width, height,
         } = map.value?.getBoundingClientRect() || {
@@ -274,8 +275,12 @@ export default defineComponent({
               || note.notePositionY > top + height
               || note.notePositionX < left
               || note.notePositionY < top
-              || radiusForZoomLevel(zoomLevel.value, (pin as Pin).minimum_zoom || 0) === 0
-              || opacityForZoomLevel(zoomLevel.value, (pin as Pin).maximum_zoom || 40) === 0) {
+              || radiusForZoomLevel(
+                zoomLevel.value,
+                pinObject.minimum_zoom || 0,
+                pinObject.maximum_zoom || 40,
+              ) === 0
+              || opacityForZoomLevel(zoomLevel.value, pinObject.maximum_zoom || 40) === 0) {
             note.inBounds = false;
           } else {
             note.inBounds = true;
@@ -287,7 +292,7 @@ export default defineComponent({
     function showHidePinsForZoomLevel(level: number) {
       if (pinFeature) {
         pinFeature.style('radius', (pin: Pin) => (
-          radiusForZoomLevel(level, pin.minimum_zoom)
+          radiusForZoomLevel(level, pin.minimum_zoom, pin.maximum_zoom)
         ));
         pinFeature.style('fillOpacity', (pin: Pin) => (
           opacityForZoomLevel(level, pin.maximum_zoom)

--- a/web/src/views/InvestigationDetail.vue
+++ b/web/src/views/InvestigationDetail.vue
@@ -122,7 +122,12 @@ import {
 } from '@vue/composition-api';
 import { MouseClickEvent, GeoJSLayer, GeoJSFeature } from '../utilities/composableTypes';
 import useGeoJS from '../utilities/useGeoJS';
-import { postGisToPoint, Point } from '../utilities/utiltyFunctions';
+import {
+  postGisToPoint,
+  Point,
+  radiusForZoomLevel,
+  opacityForZoomLevel,
+} from '../utilities/utiltyFunctions';
 import store, { TiffFrame } from '../store';
 import InvestigationSidebar from '../components/InvestigationSidebar.vue';
 import InvestigationDetailFrameMenu from '../components/InvestigationDetailFrameMenu.vue';
@@ -269,8 +274,8 @@ export default defineComponent({
               || note.notePositionY > top + height
               || note.notePositionX < left
               || note.notePositionY < top
-              || zoomLevel.value < ((pin as Pin).minimum_zoom || 0)
-              || zoomLevel.value > ((pin as Pin).maximum_zoom || 40)) {
+              || radiusForZoomLevel(zoomLevel.value, (pin as Pin).minimum_zoom || 0) === 0
+              || opacityForZoomLevel(zoomLevel.value, (pin as Pin).maximum_zoom || 40) === 0) {
             note.inBounds = false;
           } else {
             note.inBounds = true;
@@ -281,10 +286,15 @@ export default defineComponent({
 
     function showHidePinsForZoomLevel(level: number) {
       if (pinFeature) {
+        pinFeature.style('radius', (pin: Pin) => (
+          radiusForZoomLevel(level, pin.minimum_zoom)
+        ));
         pinFeature.style('fillOpacity', (pin: Pin) => (
-          (level >= (pin.minimum_zoom || 0) && level <= (pin.maximum_zoom || 40)) ? 0.8 : 0));
+          opacityForZoomLevel(level, pin.maximum_zoom)
+        ));
         pinFeature.style('strokeOpacity', (pin: Pin) => (
-          (level >= (pin.minimum_zoom || 0) && level <= (pin.maximum_zoom || 40)) ? 0.8 : 0));
+          opacityForZoomLevel(level, pin.maximum_zoom)
+        ));
         pinFeature.draw();
       }
     }


### PR DESCRIPTION
This PR attempts to enhance user experience by introducing simple transitions as a user zooms through a map, causing pins to appear/disappear based on their minimum and maximum zoom levels.

While when approaching a pin by zooming, the pin will appear to grow until the user hits the minimum zoom level for that pin. When zooming beyond a pin's maximum zoom level, its opacity will decrease from maximum to 0. I believe this nicely simulates zooming "past" the scale where the pin would be useful to display, but I'm open to other ideas for transitions.

Resolves #175 