### PR TITLE
Anatomy datasets

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+**/anatomy/* filter=lfs diff=lfs merge=lfs -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,12 @@
-**/anatomy/* filter=lfs diff=lfs merge=lfs -text
+atlascope/core/management/populate/inputs/anatomy/reproductive_male.tiff filter=lfs diff=lfs merge=lfs -text
+atlascope/core/management/populate/inputs/anatomy/skeletal.tiff filter=lfs diff=lfs merge=lfs -text
+atlascope/core/management/populate/inputs/anatomy/digestive.tiff filter=lfs diff=lfs merge=lfs -text
+atlascope/core/management/populate/inputs/anatomy/endocrine.tiff filter=lfs diff=lfs merge=lfs -text
+atlascope/core/management/populate/inputs/anatomy/integumentary.tiff filter=lfs diff=lfs merge=lfs -text
+atlascope/core/management/populate/inputs/anatomy/lymphatic.tiff filter=lfs diff=lfs merge=lfs -text
+atlascope/core/management/populate/inputs/anatomy/muscular.tiff filter=lfs diff=lfs merge=lfs -text
+atlascope/core/management/populate/inputs/anatomy/reproductive_female.tiff filter=lfs diff=lfs merge=lfs -text
+atlascope/core/management/populate/inputs/anatomy/circulatory.tiff filter=lfs diff=lfs merge=lfs -text
+atlascope/core/management/populate/inputs/anatomy/nervous.tiff filter=lfs diff=lfs merge=lfs -text
+atlascope/core/management/populate/inputs/anatomy/respiratory.tiff filter=lfs diff=lfs merge=lfs -text
+atlascope/core/management/populate/inputs/anatomy/urinary.tiff filter=lfs diff=lfs merge=lfs -text

--- a/atlascope/core/management/populate/datasets.json
+++ b/atlascope/core/management/populate/datasets.json
@@ -64,5 +64,77 @@
         "description": "A speckled green PNG image",
         "content": "green.png",
         "dataset_type": "non_tiled_image"
+    },
+    {
+        "name": "Human circulatory system",
+        "id": 2988,
+        "description": "A basic anatomical illustration of the circulatory system",
+        "content": "anatomy/circulatory.tiff"
+    },
+    {
+        "name": "Human digestive system",
+        "id": 2989,
+        "description": "A basic anatomical illustration of the digestive system",
+        "content": "anatomy/digestive.tiff"
+    },
+    {
+        "name": "Human endocrine system",
+        "id": 2990,
+        "description": "A basic anatomical illustration of the endocrine system",
+        "content": "anatomy/endocrine.tiff"
+    },
+    {
+        "name": "Human integumentary system",
+        "id": 2991,
+        "description": "A basic anatomical illustration of the integumentary system",
+        "content": "anatomy/integumentary.tiff"
+    },
+    {
+        "name": "Human lymphatic system",
+        "id": 2992,
+        "description": "A basic anatomical illustration of the lymphatic system",
+        "content": "anatomy/lymphatic.tiff"
+    },
+    {
+        "name": "Human muscular system",
+        "id": 2993,
+        "description": "A basic anatomical illustration of the muscular system",
+        "content": "anatomy/muscular.tiff"
+    },
+    {
+        "name": "Human nervous system",
+        "id": 2994,
+        "description": "A basic anatomical illustration of the nervous system",
+        "content": "anatomy/nervous.tiff"
+    },
+    {
+        "name": "Female reproductive system",
+        "id": 2995,
+        "description": "A basic anatomical illustration of the female reproductive system",
+        "content": "anatomy/reproductive_female.tiff"
+    },
+    {
+        "name": "Male reproductive system",
+        "id": 2996,
+        "description": "A basic anatomical illustration of the male reproductive system",
+        "content": "anatomy/reproductive_male.tiff"
+    },
+    {
+        "name": "Human respiratory system",
+        "id": 2997,
+        "description": "A basic anatomical illustration of the respiratory system",
+        "content": "anatomy/respiratory.tiff"
+    },
+    {
+        "name": "Human skeletal system",
+        "id": 2998,
+        "description": "A basic anatomical illustration of the skeletal system",
+        "content": "anatomy/skeletal.tiff"
+    },
+    {
+        "name": "Human urinary system",
+        "id": 2999,
+        "description": "A basic anatomical illustration of the urinary system",
+        "content": "anatomy/urinary.tiff"
     }
 ]

--- a/atlascope/core/management/populate/embeddings.json
+++ b/atlascope/core/management/populate/embeddings.json
@@ -2,13 +2,20 @@
     {
         "investigation": "Semantic zoom playground",
         "id": 3000,
+        "parent": "Human muscular system",
+        "child": "HTA9_1_BA_F_ROI02",
+        "child_bounding_box": [2200, 2500, 2205, 2505]
+    },
+    {
+        "investigation": "Semantic zoom playground",
+        "id": 3001,
         "parent": "HTA9_1_BA_F_ROI02",
         "child": "HTA9_1_BA_F_ROI04",
         "child_bounding_box": [100, 100, 200, 200]
     },
     {
         "investigation": "Semantic zoom playground",
-        "id": 3001,
+        "id": 3002,
         "parent": "HTA9_1_BA_F_ROI02",
         "child": "HTA9_1_BA_F_ROI03",
         "child_bounding_box": [600, 500, 200, 200]

--- a/atlascope/core/management/populate/inputs/anatomy/circulatory.tiff
+++ b/atlascope/core/management/populate/inputs/anatomy/circulatory.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:696ea574d3e23e1310a24d5467689f87f9682f4a57f1cbfb9192b7c0bca8ed7b
+size 135087830

--- a/atlascope/core/management/populate/inputs/anatomy/digestive.tiff
+++ b/atlascope/core/management/populate/inputs/anatomy/digestive.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:42071ad0acf72adf1209fc6cdb2b4634ef1c18d4bf090dfe6a031ca6ac8cc8a9
+size 135087830

--- a/atlascope/core/management/populate/inputs/anatomy/endocrine.tiff
+++ b/atlascope/core/management/populate/inputs/anatomy/endocrine.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4134bd2cfdb7ec0a06e852c70e2d7a6190046c47504d140dd8b47f9b12850f73
+size 135087830

--- a/atlascope/core/management/populate/inputs/anatomy/integumentary.tiff
+++ b/atlascope/core/management/populate/inputs/anatomy/integumentary.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f3901b42d3bf695cb411eb9b8f9dce2a03bc2277d646115cb419973cc3fdbca2
+size 135087830

--- a/atlascope/core/management/populate/inputs/anatomy/lymphatic.tiff
+++ b/atlascope/core/management/populate/inputs/anatomy/lymphatic.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:85de7d7ce7cead00b7e0c9c972bc64b1df91d121a3ca16a5a8a3fad7ea8ab6dd
+size 135087830

--- a/atlascope/core/management/populate/inputs/anatomy/muscular.tiff
+++ b/atlascope/core/management/populate/inputs/anatomy/muscular.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6913b86de549da1c3e60f2a63d92857a9928b7fc9de4a002b076c9a7dd3369e7
+size 135087830

--- a/atlascope/core/management/populate/inputs/anatomy/nervous.tiff
+++ b/atlascope/core/management/populate/inputs/anatomy/nervous.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4ad18533e98ce6268e5bdfd5cf766efc38830afc856145722ca078945b28317
+size 135087830

--- a/atlascope/core/management/populate/inputs/anatomy/reproductive_female.tiff
+++ b/atlascope/core/management/populate/inputs/anatomy/reproductive_female.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c4c3b036c430e2b661fa4206420dea2561386a9034c0e814783304a31b2c1f5
+size 135087830

--- a/atlascope/core/management/populate/inputs/anatomy/reproductive_male.tiff
+++ b/atlascope/core/management/populate/inputs/anatomy/reproductive_male.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2cd2dc6d4ab355afed776fcb6910900b2ab13dd0049c8b4430439171de281301
+size 135087830

--- a/atlascope/core/management/populate/inputs/anatomy/respiratory.tiff
+++ b/atlascope/core/management/populate/inputs/anatomy/respiratory.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1422c220ee61f41ec63311ecc5cb6eaa86f33982ec0ba27d5d5c318179b214f8
+size 135087830

--- a/atlascope/core/management/populate/inputs/anatomy/skeletal.tiff
+++ b/atlascope/core/management/populate/inputs/anatomy/skeletal.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:49802eec463e5737ca1836064504731f60a6e936983a4aa8a571c52137848a92
+size 135087830

--- a/atlascope/core/management/populate/inputs/anatomy/urinary.tiff
+++ b/atlascope/core/management/populate/inputs/anatomy/urinary.tiff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:696ea574d3e23e1310a24d5467689f87f9682f4a57f1cbfb9192b7c0bca8ed7b
+size 135087830

--- a/atlascope/core/management/populate/investigations.json
+++ b/atlascope/core/management/populate/investigations.json
@@ -13,6 +13,7 @@
         "name": "Semantic zoom playground",
         "id": 1001,
         "datasets": [
+            "Human muscular system",
             "HTA9_1_BA_F_ROI02",
             "HTA9_1_BA_F_ROI04",
             "HTA9_1_BA_F_ROI03"

--- a/web/src/views/InvestigationDetail.vue
+++ b/web/src/views/InvestigationDetail.vue
@@ -159,7 +159,7 @@ interface NonTiledOverlayFeatureData {
   ul: Point;
   lr: Point;
   image: HTMLImageElement;
-  pinId: number;
+  pinId: number | undefined;
 }
 
 interface BandSpec {
@@ -236,6 +236,9 @@ export default defineComponent({
     }
 
     function buildUrlQueryArgs() {
+      if (frames.value.length === 0) {
+        return '';
+      }
       const style: TileLayerStyleDict = {
         bands: getSelectedFrameStyle(),
       };
@@ -254,7 +257,7 @@ export default defineComponent({
       if (!featureLayer || !pinFeature || !map.value) { return; }
       pinFeature.getData().forEach((pin: object) => {
         if (!pinFeature) return;
-        const { x, y } = postGisToPoint((pin as Pin).location) || { x: 0, y: 0 };
+        const { x, y } = postGisToPoint((pin as Pin).child_location) || { x: 0, y: 0 };
         const newScreenCoords = pinFeature.featureGcsToDisplay(x, y);
         const note = pinNotes.value.find((pinNote) => pinNote.id === (pin as Pin).id);
         const {
@@ -501,7 +504,7 @@ export default defineComponent({
     // Create note cards for any pins without a child dataset.
     function createPinNotes() {
       const noteOnlyPins = store.state.currentPins.filter(
-        (pin: Pin) => pin.pin_type === 'NotePin',
+        (pin: Pin) => (!pin.child && pin.note?.length),
       );
       pinNotes.value = noteOnlyPins.map((pin) => ({
         ...pin,
@@ -543,7 +546,7 @@ export default defineComponent({
         image.src = url;
         image.crossOrigin = 'use-credentials';
         const imageMetadata = (await store.state.axiosInstance.get(`${urlRoot}/datasets/tile_source/${dataset.id}/metadata`)).data;
-        const ul = postGisToPoint(pin.location) || { x: 0, y: 0 };
+        const ul = postGisToPoint(pin.child_location) || { x: 0, y: 0 };
         const lr = {
           x: ul.x + (imageMetadata.sizeX || 0),
           y: ul.y + (imageMetadata.sizeY || 0),
@@ -607,7 +610,7 @@ export default defineComponent({
       if (!pinFeature) {
         pinFeature = featureLayer.createFeature('point');
         pinFeature.data(selectedPins.value);
-        pinFeature.position((pin: Pin) => (postGisToPoint(pin.location) || { x: 0, y: 0 }));
+        pinFeature.position((pin: Pin) => (postGisToPoint(pin.child_location) || { x: 0, y: 0 }));
         pinFeature.style({
           radius: 10,
           strokeColor: 'white',
@@ -619,14 +622,14 @@ export default defineComponent({
 
           if (event.mouse.buttonsDown.left) {
             const pinClicked = event.data as Pin;
-            if (pinClicked.pin_type === 'NotePin') {
+            if (!pinClicked.child && pinClicked.note) {
               const noteToToggle = pinNotes.value.find((note) => note.id === pinClicked.id);
               if (noteToToggle) {
                 noteToToggle.showNote = !noteToToggle.showNote;
                 noteToToggle.notePositionX = event.mouse.page.x;
                 noteToToggle.notePositionY = event.mouse.page.y;
               }
-            } else if (pinClicked.pin_type === 'DatasetPin') {
+            } else if (pinClicked.child) {
               toggleDatasetPin(pinClicked);
             }
           }


### PR DESCRIPTION
Be sure to do `git lfs fetch` and `git lfs pull` before trying out this branch!

This PR adds 12 datasets, each with a tiled tiff image of some system in human anatomy. To demonstrate how these datasets can be useful for context in an investigation, the muscular system is used as the root dataset of the `Semantic zoom playground` Investigation:

![image](https://user-images.githubusercontent.com/44912689/175052933-f3413a75-b592-42d1-80c2-f31eabaf2f94.png)

We should consider what it might look like for an investigation to use multiple anatomy datasets as parallel root datasets, each with their own embeddings tree.