### PR TITLE
Add endpoint to download datasets

### DIFF
--- a/atlascope/core/rest/endpoints/dataset_endpoints.py
+++ b/atlascope/core/rest/endpoints/dataset_endpoints.py
@@ -75,7 +75,7 @@ class DatasetViewSet(
         dataset = self.get_object()
         try:
             path = dataset.content.path
-        except Exception:
+        except (AttributeError, ValueError):
             raise ValidationError('Dataset has no content')
         if os.path.exists(path):
             response = FileResponse(open(path, 'rb'), content_type='application/octet-stream')


### PR DESCRIPTION
Datasets can now be downloaded via `/api/v1/datasets/<id>/download`

This endpoint is being added specifically for integrating a local instance of ParaviewGlance, but could be useful for other purposes.