### PR TITLE
Include `3d_volume` pins in display types

### DIFF
--- a/web/src/store/index.ts
+++ b/web/src/store/index.ts
@@ -329,6 +329,7 @@ const {
       const circlePinDatasetTypes = [
         'tile_overlay',
         'non_tiled_image',
+        '3d_volume',
       ];
       const isVisualization: Array<boolean | Dataset> = pins.map((pin: Pin) => {
         const childDataset: Dataset | undefined = store.state.currentDatasets.find(


### PR DESCRIPTION
This fixes a bug that was precluding 3d volume pins from being displayed in investigations.

This is further evidence that the pin concept has become overloaded in this codebase (something to address in a possible Phase 2; see #206).

Thanks to @marySalvi for information and context, and @naglepuff for helping me find/fix the error.